### PR TITLE
Update UNLICENSED contracts to GPL

### DIFF
--- a/contracts/interfaces/IERC20Metadata.sol
+++ b/contracts/interfaces/IERC20Metadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.7.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.7.0;
 pragma abicoder v2;
 


### PR DESCRIPTION
This is confusing to devs who are repurposing this code (specifically NFTDescriptor lib). These contracts should have been updated previously to GPL before deployment.

Leaving test contracts as unlicensed for now.