### PR TITLE
Removing redundant checks

### DIFF
--- a/contracts/libraries/LiquidityAmounts.sol
+++ b/contracts/libraries/LiquidityAmounts.sol
@@ -16,6 +16,7 @@ library LiquidityAmounts {
 
     /// @notice Computes the amount of liquidity received for a given amount of token0 and price range
     /// @dev Calculates amount0 * (sqrt(upper) * sqrt(lower)) / (sqrt(upper) - sqrt(lower))
+    /// Requires sqrt(upper) to be greater than sqrt(lower)
     /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
     /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
     /// @param amount0 The amount0 being sent in
@@ -25,13 +26,12 @@ library LiquidityAmounts {
         uint160 sqrtRatioBX96,
         uint256 amount0
     ) internal pure returns (uint128 liquidity) {
-        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
         uint256 intermediate = FullMath.mulDiv(sqrtRatioAX96, sqrtRatioBX96, FixedPoint96.Q96);
         return toUint128(FullMath.mulDiv(amount0, intermediate, sqrtRatioBX96 - sqrtRatioAX96));
     }
 
     /// @notice Computes the amount of liquidity received for a given amount of token1 and price range
-    /// @dev Calculates amount1 / (sqrt(upper) - sqrt(lower)).
+    /// @dev Calculates amount1 / (sqrt(upper) - sqrt(lower)). Requires sqrt(upper) to be greater than sqrt(lower)
     /// @param sqrtRatioAX96 A sqrt price representing the first tick boundary
     /// @param sqrtRatioBX96 A sqrt price representing the second tick boundary
     /// @param amount1 The amount1 being sent in
@@ -41,7 +41,6 @@ library LiquidityAmounts {
         uint160 sqrtRatioBX96,
         uint256 amount1
     ) internal pure returns (uint128 liquidity) {
-        if (sqrtRatioAX96 > sqrtRatioBX96) (sqrtRatioAX96, sqrtRatioBX96) = (sqrtRatioBX96, sqrtRatioAX96);
         return toUint128(FullMath.mulDiv(amount1, FixedPoint96.Q96, sqrtRatioBX96 - sqrtRatioAX96));
     }
 

--- a/contracts/libraries/Path.sol
+++ b/contracts/libraries/Path.sol
@@ -19,7 +19,7 @@ library Path {
     /// @dev The minimum length of an encoding that contains 2 or more pools
     uint256 private constant MULTIPLE_POOLS_MIN_LENGTH = POP_OFFSET + NEXT_OFFSET;
 
-    /// @notice Returns true iff the path contains two or more pools
+    /// @notice Returns true if the path contains two or more pools
     /// @param path The encoded swap path
     /// @return True if path contains two or more pools, otherwise false
     function hasMultiplePools(bytes memory path) internal pure returns (bool) {


### PR DESCRIPTION
The two internal functions,`getLiquidityForAmount0` and `getLiquidityForAmount1`, are only called in the below `getLiquidityForAmounts` function.
https://github.com/Uniswap/v3-periphery/blob/main/contracts/libraries/LiquidityAmounts.sol#L56-L75

The `if-else` branch of the `getLiquidityForAmounts` function already done the validation of the parameters passed into the `getLiquidityForAmount0` function and `getLiquidityForAmount1` function. I.e., make the first parameter passed into the `getLiquidityForAmount0` function less than the second parameter. Same validation done to the parameter passed into the `getLiquidityForAmount1` function. 

So, there is no need to repeatedly do the same validations in the `getLiquidityForAmount0` function and the `getLiquidityForAmount1` function.