### PR TITLE
Synchronize openzeppelin

### DIFF
--- a/contracts/interfaces/INonfungiblePositionManager.sol
+++ b/contracts/interfaces/INonfungiblePositionManager.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-import '@openzeppelin/contracts/token/ERC721/IERC721Metadata.sol';
-import '@openzeppelin/contracts/token/ERC721/IERC721Enumerable.sol';
+import '@openzeppelin/contracts/interfaces/IERC721Metadata.sol';
+import '@openzeppelin/contracts/interfaces/IERC721Enumerable.sol';
 
 import './IPoolInitializer.sol';
 import './IERC721Permit.sol';

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -26,23 +26,4 @@ library PoolAddress {
         return PoolKey({token0: tokenA, token1: tokenB, fee: fee});
     }
 
-    /// @notice Deterministically computes the pool address given the factory and PoolKey
-    /// @param factory The Uniswap V3 factory contract address
-    /// @param key The PoolKey
-    /// @return pool The contract address of the V3 pool
-    function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
-        require(key.token0 < key.token1);
-        pool = address(
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        hex'ff',
-                        factory,
-                        keccak256(abi.encode(key.token0, key.token1, key.fee)),
-                        POOL_INIT_CODE_HASH
-                    )
-                )
-            )
-        );
-    }
 }


### PR DESCRIPTION
Hello Uniswap.

I met two errors in your `v3-periphery` repo.

## First

![image](https://user-images.githubusercontent.com/44861205/153049422-23e8e9a3-281e-4f72-b1fd-03a2d5d9d3cc.png)

 The error message said like `Error HH404: File @openzeppelin/contracts/token/ERC721/IERC721Metadata.sol, imported from @uniswap/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol, not found.`

`IERC721Metadata.sol` and `IERC721Enumerable.sol` in `openzeppelin-contracts` are not included in this path like `@openzeppelin/contracts/token/ERC721` no more, but those are included in `@openzeppelin/contracts/interfaces`

I found the fact that openzeppelin update some path before 2 months.

So this openzeppelin updating is not applied in `v3-periphery` repo.

## Second

![image](https://user-images.githubusercontent.com/44861205/153049844-02c11aa8-eb16-4532-b809-d3c40fef8739.png)

This is occured in `computeAddress` function which is located in `@uniswap/v3-periphery/contracts/libraries/PoolAddress.sol`

But I wonder that this function can remove in `v3-periphery` repo

So If this function removing is not right, I will restore this function.

## Result

I think that first issue must apply in this repo, but second issue is not





