### PR TITLE
Convert from solc 0.7.6 to 0.8.11

### DIFF
--- a/contracts/NonfungiblePositionManager.sol
+++ b/contracts/NonfungiblePositionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
@@ -192,7 +192,7 @@ contract NonfungiblePositionManager is
     }
 
     // save bytecode by removing implementation of unused method
-    function baseURI() public pure override returns (string memory) {}
+    // function baseURI() public pure returns (string memory) {}
 
     /// @inheritdoc INonfungiblePositionManager
     function increaseLiquidity(IncreaseLiquidityParams calldata params)

--- a/contracts/NonfungibleTokenPositionDescriptor.sol
+++ b/contracts/NonfungibleTokenPositionDescriptor.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
-import '@uniswap/lib/contracts/libraries/SafeERC20Namer.sol';
 
+import './libraries/SafeERC20Namer.sol';
 import './libraries/ChainId.sol';
 import './interfaces/INonfungiblePositionManager.sol';
 import './interfaces/INonfungibleTokenPositionDescriptor.sol';

--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/contracts/V3Migrator.sol
+++ b/contracts/V3Migrator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/LowGasSafeMath.sol';

--- a/contracts/base/BlockTimestamp.sol
+++ b/contracts/base/BlockTimestamp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 /// @title Function for getting block timestamp
 /// @dev Base contract that is overridden for tests

--- a/contracts/base/ERC721Permit.sol
+++ b/contracts/base/ERC721Permit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '@openzeppelin/contracts/utils/Address.sol';

--- a/contracts/base/LiquidityManagement.sol
+++ b/contracts/base/LiquidityManagement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';

--- a/contracts/base/Multicall.sol
+++ b/contracts/base/Multicall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '../interfaces/IMulticall.sol';

--- a/contracts/base/PeripheryImmutableState.sol
+++ b/contracts/base/PeripheryImmutableState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../interfaces/IPeripheryImmutableState.sol';
 

--- a/contracts/base/PeripheryValidation.sol
+++ b/contracts/base/PeripheryValidation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import './BlockTimestamp.sol';
 

--- a/contracts/base/PoolInitializer.sol
+++ b/contracts/base/PoolInitializer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/base/SelfPermit.sol
+++ b/contracts/base/SelfPermit.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.5.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts/drafts/IERC20Permit.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol';
 
 import '../interfaces/ISelfPermit.sol';
 import '../interfaces/external/IERC20PermitAllowed.sol';

--- a/contracts/examples/PairFlash.sol
+++ b/contracts/examples/PairFlash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol';

--- a/contracts/interfaces/IERC20Metadata.sol
+++ b/contracts/interfaces/IERC20Metadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.7.0;
+pragma solidity =0.8.11;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/interfaces/INonfungiblePositionManager.sol
+++ b/contracts/interfaces/INonfungiblePositionManager.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-import '@openzeppelin/contracts/token/ERC721/IERC721Metadata.sol';
-import '@openzeppelin/contracts/token/ERC721/IERC721Enumerable.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol';
 
 import './IPoolInitializer.sol';
 import './IERC721Permit.sol';
@@ -19,7 +19,7 @@ interface INonfungiblePositionManager is
     IPeripheryPayments,
     IPeripheryImmutableState,
     IERC721Metadata,
-    IERC721Enumerable,
+    // IERC721Enumerable,
     IERC721Permit
 {
     /// @notice Emitted when liquidity is increased for a position NFT

--- a/contracts/interfaces/external/IWETH9.sol
+++ b/contracts/interfaces/external/IWETH9.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/lens/Quoter.sol
+++ b/contracts/lens/Quoter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/contracts/lens/QuoterV2.sol
+++ b/contracts/lens/QuoterV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/contracts/lens/TickLens.sol
+++ b/contracts/lens/TickLens.sol
@@ -29,7 +29,7 @@ contract TickLens is ITickLens {
         populatedTicks = new PopulatedTick[](numberOfPopulatedTicks);
         for (uint256 i = 0; i < 256; i++) {
             if (bitmap & (1 << i) > 0) {
-                int24 populatedTick = ((int24(tickBitmapIndex) << 8) + int24(i)) * tickSpacing;
+                int24 populatedTick = ((int24(tickBitmapIndex) << 8) + int24(int256(i))) * tickSpacing;
                 (uint128 liquidityGross, int128 liquidityNet, , , , , , ) = IUniswapV3Pool(pool).ticks(populatedTick);
                 populatedTicks[--numberOfPopulatedTicks] = PopulatedTick({
                     tick: populatedTick,

--- a/contracts/lens/UniswapInterfaceMulticall.sol
+++ b/contracts/lens/UniswapInterfaceMulticall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 /// @notice A fork of Multicall2 specifically tailored for the Uniswap Interface

--- a/contracts/libraries/AddressStringUtil.sol
+++ b/contracts/libraries/AddressStringUtil.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity >=0.5.0;
+
+library AddressStringUtil {
+    // converts an address to the uppercase hex string, extracting only len bytes (up to 20, multiple of 2)
+    function toAsciiString(address addr, uint256 len) internal pure returns (string memory) {
+        require(len % 2 == 0 && len > 0 && len <= 40, 'AddressStringUtil: INVALID_LEN');
+
+        bytes memory s = new bytes(len);
+        uint256 addrNum = uint256(uint160(addr));
+        for (uint256 i = 0; i < len / 2; i++) {
+            // shift right and truncate all but the least significant byte to extract the byte at position 19-i
+            uint8 b = uint8(addrNum >> (8 * (19 - i)));
+            // first hex character is the most significant 4 bits
+            uint8 hi = b >> 4;
+            // second hex character is the least significant 4 bits
+            uint8 lo = b - (hi << 4);
+            s[2 * i] = char(hi);
+            s[2 * i + 1] = char(lo);
+        }
+        return string(s);
+    }
+
+    // hi and lo are only 4 bits and between 0 and 16
+    // this method converts those values to the unicode/ascii code point for the hex representation
+    // uses upper case for the characters
+    function char(uint8 b) private pure returns (bytes1 c) {
+        if (b < 10) {
+            return bytes1(b + 0x30);
+        } else {
+            return bytes1(b + 0x37);
+        }
+    }
+}

--- a/contracts/libraries/BytesLib.sol
+++ b/contracts/libraries/BytesLib.sol
@@ -6,7 +6,7 @@
  * @dev Bytes tightly packed arrays utility library for ethereum contracts written in Solidity.
  *      The library lets you concatenate, slice and type cast bytes arrays both in memory and storage.
  */
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity =0.8.11;
 
 library BytesLib {
     function slice(

--- a/contracts/libraries/CallbackValidation.sol
+++ b/contracts/libraries/CallbackValidation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import './PoolAddress.sol';

--- a/contracts/libraries/ChainId.sol
+++ b/contracts/libraries/ChainId.sol
@@ -5,9 +5,12 @@ pragma solidity >=0.7.0;
 library ChainId {
     /// @dev Gets the current chain ID
     /// @return chainId The current chain ID
-    function get() internal pure returns (uint256 chainId) {
+    function get() internal view returns (uint256 chainId) {
+        return block.chainid;
+        /*
         assembly {
             chainId := chainid()
         }
+        */
     }
 }

--- a/contracts/libraries/HexStrings.sol
+++ b/contracts/libraries/HexStrings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 library HexStrings {
     bytes16 internal constant ALPHABET = '0123456789abcdef';

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -6,11 +6,11 @@ import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 import '@uniswap/v3-core/contracts/libraries/BitMath.sol';
 import '@uniswap/v3-core/contracts/libraries/FullMath.sol';
-import '@openzeppelin/contracts/utils/Strings.sol';
-import '@openzeppelin/contracts/math/SafeMath.sol';
-import '@openzeppelin/contracts/math/SignedSafeMath.sol';
+import '@openzeppelin/contracts/utils/math/SafeMath.sol';
+import '@openzeppelin/contracts/utils/math/SignedSafeMath.sol';
 import 'base64-sol/base64.sol';
 import './HexStrings.sol';
+import './ozToString.sol';
 import './NFTSVG.sol';
 
 library NFTDescriptor {
@@ -273,7 +273,7 @@ library NFTDescriptor {
         uint8 baseTokenDecimals,
         uint8 quoteTokenDecimals
     ) private pure returns (uint256 adjustedSqrtRatioX96) {
-        uint256 difference = abs(int256(baseTokenDecimals).sub(int256(quoteTokenDecimals)));
+        uint256 difference = abs(int256(uint256(baseTokenDecimals)).sub(int256(uint256(quoteTokenDecimals))));
         if (difference > 0 && difference <= 18) {
             if (baseTokenDecimals > quoteTokenDecimals) {
                 adjustedSqrtRatioX96 = sqrtRatioX96.mul(10**(difference.div(2)));
@@ -403,7 +403,7 @@ library NFTDescriptor {
     }
 
     function addressToString(address addr) internal pure returns (string memory) {
-        return (uint256(addr)).toHexString(20);
+        return (uint256(uint160(addr))).toHexString(20);
     }
 
     function generateSVGImage(ConstructTokenURIParams memory params) internal pure returns (string memory svg) {
@@ -420,16 +420,16 @@ library NFTDescriptor {
                 tickSpacing: params.tickSpacing,
                 overRange: overRange(params.tickLower, params.tickUpper, params.tickCurrent),
                 tokenId: params.tokenId,
-                color0: tokenToColorHex(uint256(params.quoteTokenAddress), 136),
-                color1: tokenToColorHex(uint256(params.baseTokenAddress), 136),
-                color2: tokenToColorHex(uint256(params.quoteTokenAddress), 0),
-                color3: tokenToColorHex(uint256(params.baseTokenAddress), 0),
-                x1: scale(getCircleCoord(uint256(params.quoteTokenAddress), 16, params.tokenId), 0, 255, 16, 274),
-                y1: scale(getCircleCoord(uint256(params.baseTokenAddress), 16, params.tokenId), 0, 255, 100, 484),
-                x2: scale(getCircleCoord(uint256(params.quoteTokenAddress), 32, params.tokenId), 0, 255, 16, 274),
-                y2: scale(getCircleCoord(uint256(params.baseTokenAddress), 32, params.tokenId), 0, 255, 100, 484),
-                x3: scale(getCircleCoord(uint256(params.quoteTokenAddress), 48, params.tokenId), 0, 255, 16, 274),
-                y3: scale(getCircleCoord(uint256(params.baseTokenAddress), 48, params.tokenId), 0, 255, 100, 484)
+                color0: tokenToColorHex(uint256(uint160(params.quoteTokenAddress)), 136),
+                color1: tokenToColorHex(uint256(uint160(params.baseTokenAddress)), 136),
+                color2: tokenToColorHex(uint256(uint160(params.quoteTokenAddress)), 0),
+                color3: tokenToColorHex(uint256(uint160(params.baseTokenAddress)), 0),
+                x1: scale(getCircleCoord(uint256(uint160(params.quoteTokenAddress)), 16, params.tokenId), 0, 255, 16, 274),
+                y1: scale(getCircleCoord(uint256(uint160(params.baseTokenAddress)), 16, params.tokenId), 0, 255, 100, 484),
+                x2: scale(getCircleCoord(uint256(uint160(params.quoteTokenAddress)), 32, params.tokenId), 0, 255, 16, 274),
+                y2: scale(getCircleCoord(uint256(uint160(params.baseTokenAddress)), 32, params.tokenId), 0, 255, 100, 484),
+                x3: scale(getCircleCoord(uint256(uint160(params.quoteTokenAddress)), 48, params.tokenId), 0, 255, 16, 274),
+                y3: scale(getCircleCoord(uint256(uint160(params.baseTokenAddress)), 48, params.tokenId), 0, 255, 100, 484)
             });
 
         return NFTSVG.generateSVG(svgParams);

--- a/contracts/libraries/NFTSVG.sol
+++ b/contracts/libraries/NFTSVG.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.7.6;
+pragma solidity >=0.8.11;
 
-import '@openzeppelin/contracts/utils/Strings.sol';
+// import '@openzeppelin/contracts/utils/Strings.sol';
+import './ozToString.sol';
 import '@uniswap/v3-core/contracts/libraries/BitMath.sol';
 import 'base64-sol/base64.sol';
 
@@ -355,7 +356,7 @@ library NFTSVG {
             tick = tick * -1;
             sign = '-';
         }
-        return string(abi.encodePacked(sign, uint256(tick).toString()));
+        return string(abi.encodePacked(sign, uint256(int256(tick)).toString()));
     }
 
     function rangeLocation(int24 tickLower, int24 tickUpper) internal pure returns (string memory, string memory) {

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0 <0.8.0;
+pragma solidity =0.8.11;
 
 import '@uniswap/v3-core/contracts/libraries/FullMath.sol';
 import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
@@ -31,9 +31,9 @@ library OracleLibrary {
         uint160 secondsPerLiquidityCumulativesDelta =
             secondsPerLiquidityCumulativeX128s[1] - secondsPerLiquidityCumulativeX128s[0];
 
-        arithmeticMeanTick = int24(tickCumulativesDelta / secondsAgo);
+        arithmeticMeanTick = int24(tickCumulativesDelta / int56(uint56(secondsAgo)));
         // Always round to negative infinity
-        if (tickCumulativesDelta < 0 && (tickCumulativesDelta % secondsAgo != 0)) arithmeticMeanTick--;
+        if (tickCumulativesDelta < 0 && (tickCumulativesDelta % int56(uint56(secondsAgo))) != 0) arithmeticMeanTick--;
 
         // We are multiplying here instead of shifting to ensure that harmonicMeanLiquidity doesn't overflow uint128
         uint192 secondsAgoX160 = uint192(secondsAgo) * type(uint160).max;
@@ -116,7 +116,7 @@ library OracleLibrary {
         require(prevInitialized, 'ONI');
 
         uint32 delta = observationTimestamp - prevObservationTimestamp;
-        tick = int24((tickCumulative - prevTickCumulative) / delta);
+        tick = int24((tickCumulative - prevTickCumulative) / int56(uint56(delta)));
         uint128 liquidity =
             uint128(
                 (uint192(delta) * type(uint160).max) /
@@ -150,7 +150,7 @@ library OracleLibrary {
 
         // Products fit in 152 bits, so it would take an array of length ~2**104 to overflow this logic
         for (uint256 i; i < weightedTickData.length; i++) {
-            numerator += weightedTickData[i].tick * int256(weightedTickData[i].weight);
+            numerator += weightedTickData[i].tick * int256(uint256(weightedTickData[i].weight));
             denominator += weightedTickData[i].weight;
         }
 

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -33,13 +33,15 @@ library PoolAddress {
     function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
         require(key.token0 < key.token1);
         pool = address(
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        hex'ff',
-                        factory,
-                        keccak256(abi.encode(key.token0, key.token1, key.fee)),
-                        POOL_INIT_CODE_HASH
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex'ff',
+                            factory,
+                            keccak256(abi.encode(key.token0, key.token1, key.fee)),
+                            POOL_INIT_CODE_HASH
+                        )
                     )
                 )
             )

--- a/contracts/libraries/PoolTicksCounter.sol
+++ b/contracts/libraries/PoolTicksCounter.sol
@@ -23,10 +23,10 @@ library PoolTicksCounter {
         {
             // Get the key and offset in the tick bitmap of the active tick before and after the swap.
             int16 wordPos = int16((tickBefore / self.tickSpacing()) >> 8);
-            uint8 bitPos = uint8((tickBefore / self.tickSpacing()) % 256);
+            uint8 bitPos = uint8(uint24((tickBefore / self.tickSpacing()) % 256));
 
             int16 wordPosAfter = int16((tickAfter / self.tickSpacing()) >> 8);
-            uint8 bitPosAfter = uint8((tickAfter / self.tickSpacing()) % 256);
+            uint8 bitPosAfter = uint8(uint24((tickAfter / self.tickSpacing()) % 256));
 
             // In the case where tickAfter is initialized, we only want to count it if we are swapping downwards.
             // If the initializable tick after the swap is initialized, our original tickAfter is a

--- a/contracts/libraries/PositionValue.sol
+++ b/contracts/libraries/PositionValue.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.6.8 <0.8.0;
+pragma solidity =0.8.11;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/libraries/FixedPoint128.sol';

--- a/contracts/libraries/SafeERC20Namer.sol
+++ b/contracts/libraries/SafeERC20Namer.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity >=0.5.0;
+
+import './AddressStringUtil.sol';
+
+// produces token descriptors from inconsistent or absent ERC20 symbol implementations that can return string or bytes32
+// this library will always produce a string symbol to represent the token
+library SafeERC20Namer {
+    function bytes32ToString(bytes32 x) private pure returns (string memory) {
+        bytes memory bytesString = new bytes(32);
+        uint256 charCount = 0;
+        for (uint256 j = 0; j < 32; j++) {
+            bytes1 char = x[j];
+            if (char != 0) {
+                bytesString[charCount] = char;
+                charCount++;
+            }
+        }
+        bytes memory bytesStringTrimmed = new bytes(charCount);
+        for (uint256 j = 0; j < charCount; j++) {
+            bytesStringTrimmed[j] = bytesString[j];
+        }
+        return string(bytesStringTrimmed);
+    }
+
+    // assumes the data is in position 2
+    function parseStringData(bytes memory b) private pure returns (string memory) {
+        uint256 charCount = 0;
+        // first parse the charCount out of the data
+        for (uint256 i = 32; i < 64; i++) {
+            charCount <<= 8;
+            charCount += uint8(b[i]);
+        }
+
+        bytes memory bytesStringTrimmed = new bytes(charCount);
+        for (uint256 i = 0; i < charCount; i++) {
+            bytesStringTrimmed[i] = b[i + 64];
+        }
+
+        return string(bytesStringTrimmed);
+    }
+
+    // uses a heuristic to produce a token name from the address
+    // the heuristic returns the full hex of the address string in upper case
+    function addressToName(address token) private pure returns (string memory) {
+        return AddressStringUtil.toAsciiString(token, 40);
+    }
+
+    // uses a heuristic to produce a token symbol from the address
+    // the heuristic returns the first 6 hex of the address string in upper case
+    function addressToSymbol(address token) private pure returns (string memory) {
+        return AddressStringUtil.toAsciiString(token, 6);
+    }
+
+    // calls an external view token contract method that returns a symbol or name, and parses the output into a string
+    function callAndParseStringReturn(address token, bytes4 selector) private view returns (string memory) {
+        (bool success, bytes memory data) = token.staticcall(abi.encodeWithSelector(selector));
+        // if not implemented, or returns empty data, return empty string
+        if (!success || data.length == 0) {
+            return '';
+        }
+        // bytes32 data always has length 32
+        if (data.length == 32) {
+            bytes32 decoded = abi.decode(data, (bytes32));
+            return bytes32ToString(decoded);
+        } else if (data.length > 64) {
+            return abi.decode(data, (string));
+        }
+        return '';
+    }
+
+    // attempts to extract the token symbol. if it does not implement symbol, returns a symbol derived from the address
+    function tokenSymbol(address token) internal view returns (string memory) {
+        // 0x95d89b41 = bytes4(keccak256("symbol()"))
+        string memory symbol = callAndParseStringReturn(token, 0x95d89b41);
+        if (bytes(symbol).length == 0) {
+            // fallback to 6 uppercase hex of address
+            return addressToSymbol(token);
+        }
+        return symbol;
+    }
+
+    // attempts to extract the token name. if it does not implement name, returns a name derived from the address
+    function tokenName(address token) internal view returns (string memory) {
+        // 0x06fdde03 = bytes4(keccak256("name()"))
+        string memory name = callAndParseStringReturn(token, 0x06fdde03);
+        if (bytes(name).length == 0) {
+            // fallback to full hex of address
+            return addressToName(token);
+        }
+        return name;
+    }
+}

--- a/contracts/libraries/TokenRatioSortOrder.sol
+++ b/contracts/libraries/TokenRatioSortOrder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 library TokenRatioSortOrder {
     int256 constant NUMERATOR_MOST = 300;

--- a/contracts/libraries/ozToString.sol
+++ b/contracts/libraries/ozToString.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/Strings.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev String operations.
+ */
+library Strings {
+    bytes16 private constant _HEX_SYMBOLS = "0123456789abcdef";
+
+    /**
+     * @dev Converts a `uint256` to its ASCII `string` decimal representation.
+     */
+    function toString(uint256 value) internal pure returns (string memory) {
+        // Inspired by OraclizeAPI's implementation - MIT licence
+        // https://github.com/oraclize/ethereum-api/blob/b42146b063c7d6ee1358846c198246239e9360e8/oraclizeAPI_0.4.25.sol
+
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/contracts/test/Base64Test.sol
+++ b/contracts/test/Base64Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import 'base64-sol/base64.sol';
 

--- a/contracts/test/LiquidityAmountsTest.sol
+++ b/contracts/test/LiquidityAmountsTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../libraries/LiquidityAmounts.sol';
 

--- a/contracts/test/MockObservable.sol
+++ b/contracts/test/MockObservable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 contract MockObservable {
     Observation private observation0;

--- a/contracts/test/MockObservations.sol
+++ b/contracts/test/MockObservations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '@uniswap/v3-core/contracts/libraries/Oracle.sol';
 

--- a/contracts/test/MockTimeNonfungiblePositionManager.sol
+++ b/contracts/test/MockTimeNonfungiblePositionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '../NonfungiblePositionManager.sol';

--- a/contracts/test/MockTimeSwapRouter.sol
+++ b/contracts/test/MockTimeSwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '../SwapRouter.sol';

--- a/contracts/test/NFTDescriptorTest.sol
+++ b/contracts/test/NFTDescriptorTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '../libraries/NFTDescriptor.sol';

--- a/contracts/test/NonfungiblePositionManagerPositionsGasTest.sol
+++ b/contracts/test/NonfungiblePositionManagerPositionsGasTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../interfaces/INonfungiblePositionManager.sol';
 

--- a/contracts/test/OracleTest.sol
+++ b/contracts/test/OracleTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '../libraries/OracleLibrary.sol';

--- a/contracts/test/PathTest.sol
+++ b/contracts/test/PathTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../libraries/Path.sol';
 

--- a/contracts/test/PeripheryImmutableStateTest.sol
+++ b/contracts/test/PeripheryImmutableStateTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../base/PeripheryImmutableState.sol';
 

--- a/contracts/test/PoolAddressTest.sol
+++ b/contracts/test/PoolAddressTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../libraries/PoolAddress.sol';
 

--- a/contracts/test/PositionValueTest.sol
+++ b/contracts/test/PositionValueTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../libraries/PositionValue.sol';
 import '../interfaces/INonfungiblePositionManager.sol';

--- a/contracts/test/SelfPermitTest.sol
+++ b/contracts/test/SelfPermitTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../base/SelfPermit.sol';
 

--- a/contracts/test/TestCallbackValidation.sol
+++ b/contracts/test/TestCallbackValidation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../libraries/CallbackValidation.sol';
 

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
-import '@openzeppelin/contracts/drafts/ERC20Permit.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol';
 
 contract TestERC20 is ERC20Permit {
     constructor(uint256 amountToMint) ERC20('Test ERC20', 'TEST') ERC20Permit('Test ERC20') {

--- a/contracts/test/TestERC20Metadata.sol
+++ b/contracts/test/TestERC20Metadata.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
-import '@openzeppelin/contracts/drafts/ERC20Permit.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol';
 
 contract TestERC20Metadata is ERC20Permit {
     constructor(

--- a/contracts/test/TestERC20PermitAllowed.sol
+++ b/contracts/test/TestERC20PermitAllowed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import './TestERC20.sol';
 import '../interfaces/external/IERC20PermitAllowed.sol';

--- a/contracts/test/TestMulticall.sol
+++ b/contracts/test/TestMulticall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 pragma abicoder v2;
 
 import '../base/Multicall.sol';

--- a/contracts/test/TestPositionNFTOwner.sol
+++ b/contracts/test/TestPositionNFTOwner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '../interfaces/external/IERC1271.sol';
 

--- a/contracts/test/TestUniswapV3Callee.sol
+++ b/contracts/test/TestUniswapV3Callee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.7.6;
+pragma solidity =0.8.11;
 
 import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,7 +5,7 @@ import 'hardhat-typechain'
 import 'hardhat-watcher'
 
 const LOW_OPTIMIZER_COMPILER_SETTINGS = {
-  version: '0.7.6',
+  version: '0.8.11',
   settings: {
     evmVersion: 'istanbul',
     optimizer: {
@@ -19,7 +19,7 @@ const LOW_OPTIMIZER_COMPILER_SETTINGS = {
 }
 
 const LOWEST_OPTIMIZER_COMPILER_SETTINGS = {
-  version: '0.7.6',
+  version: '0.8.11',
   settings: {
     evmVersion: 'istanbul',
     optimizer: {
@@ -33,7 +33,7 @@ const LOWEST_OPTIMIZER_COMPILER_SETTINGS = {
 }
 
 const DEFAULT_COMPILER_SETTINGS = {
-  version: '0.7.6',
+  version: '0.8.11',
   settings: {
     evmVersion: 'istanbul',
     optimizer: {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "3.4.1-solc-0.7-2",
+    "@openzeppelin/contracts": "^4.0.0",
     "@uniswap/lib": "^4.0.1-alpha",
     "@uniswap/v2-core": "1.0.1",
-    "@uniswap/v3-core": "1.0.0",
+    "@uniswap/v3-core": "../v3-core",
     "base64-sol": "1.0.1",
     "hardhat-watcher": "^2.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,9 +763,10 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@3.4.1-solc-0.7-2":
-  version "3.4.1-solc-0.7-2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
+"@openzeppelin/contracts@^4.0.0":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.2.tgz#4e889c9c66e736f7de189a53f8ba5b8d789425c2"
+  integrity sha512-NyJV7sJgoGYqbtNUWgzzOGW4T6rR19FmX1IJgXGdapGPWsuMelGJn9h03nos0iqfforCbCB0iYIR0MtIuIFLLw==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"
@@ -1054,10 +1055,8 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.1.tgz#af8f508bf183204779938969e2e54043e147d425"
 
-"@uniswap/v3-core@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/v3-core/-/v3-core-1.0.0.tgz#6c24adacc4c25dceee0ba3ca142b35adbd7e359d"
-  integrity sha512-kSC4djMGKMHj7sLMYVnn61k9nu+lHjMIxgg9CDQT+s2QYLoA56GbSK9Oxr+qJXzzygbkrmuY6cwgP6cW2JXPFA==
+"@uniswap/v3-core@../v3-core":
+  version "1.0.1"
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
This gets us 90% of the way there. However there are three issues:
1) A couple of OZ files were copied in directly in order to get around multiple declaration issues (hexString defined locally and in OZ) and a couple of uniswap/lib files were copied in directly. 
2) INonFungiblePositionManager extending IERC721Enumerable was commented out in order to fix broken dependencies
3) "CompilerError: Stack too deep when compiling inline assembly: Variable pos is 19 slot(s) too deep inside the stack." but I can't figure out where "pos" is, and even if I did, it sounds like a nightmare to fix. It might be possible to fix by converting to abicoder v1 to get rid of some extra stack allocations, but we need to find "pos" first.