### PR TITLE
Generalized price chaining without querying pools

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.enabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cSpell.enabled": true
-}

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -158,4 +158,16 @@ library OracleLibrary {
         // Always round to negative infinity
         if (numerator < 0 && (numerator % int256(denominator) != 0)) weightedArithmeticMeanTick--;
     }
+
+    // @notice returns the price 
+    function getChainedPrice(address[] memory tokens)
+        internal 
+        view
+        returns (int256 syntheticTick) 
+    {
+        bool lowerTicksAreWorse;
+        uint256 numTicks = path.length;
+
+        
+    }
 }

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -161,7 +161,7 @@ library OracleLibrary {
 
     /// @notice Returns the synthetic tick of the first token in the `tokens` array in terms of the last
     /// @dev Useful for relative pricing needs when a `path` does not exist, or when ticks must be returned in a customized way.
-    /// fails with "descrepant length" if number of ticks do not match the number of token pairs
+    /// fails with "descrepant length" if the number of ticks does not match the number of token pairs
     /// @param tokens The token contract addresses
     /// @param ticks The ticks, representing the price of each token pair in the tokens array
     /// @return syntheticTick The synthetic tick, represneting the relative price of the outermost tokens in the token array
@@ -171,20 +171,10 @@ library OracleLibrary {
         returns (int256 syntheticTick)
     {
         require(tokens.length - 1 == ticks.length, 'DL');
-
         for (uint256 i = 1; i <= ticks.length; i++) {
             // check the tokens for address sort order, then accumulate the
             // ticks into the running synthetic tick, ensuring that intermediate tokens "cancel out"
-            tokens[i - 1] > tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];
-
-            if (i == ticks.length) {
-                // check the token sort order of the final pair, ensuring that lower ticks represent a worse price
-                if (tokens[i - 1] > tokens[i]) {
-                    return syntheticTick;
-                } else {
-                    syntheticTick *= -1;
-                }
-            }
+            tokens[i - 1] < tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];
         }
     }
 }

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -173,7 +173,7 @@ library OracleLibrary {
         require(tokens.length - 1 == ticks.length, 'DL');
 
         for (uint256 i = 1; i <= ticks.length; i++) {
-            // check the tokens for address sort order, then accumulate the 
+            // check the tokens for address sort order, then accumulate the
             // ticks into the running synthetic ticks, ensuring that intermediate tokens "cancel out"
             tokens[i - 1] > tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];
 

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -161,7 +161,7 @@ library OracleLibrary {
 
     /// @notice Returns the "synthetic" tick which represents the price of the first entry in `tokens` in terms of the last
     /// @dev Useful for calculating relative prices along routes.
-    /// @dev There should be one tick for each pairwise set of tokens.
+    /// @dev There must be one tick for each pairwise set of tokens.
     /// @param tokens The token contract addresses
     /// @param ticks The ticks, representing the price of each token pair in `tokens`
     /// @return syntheticTick The synthetic tick, representing the relative price of the outermost tokens in `tokens`

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -163,7 +163,7 @@ library OracleLibrary {
     /// @dev Useful for relative pricing needs when a `path` does not exist, or when ticks must be returned in a customized way.
     /// fails with "descrepant length" if number of ticks do not match the number of token pairs
     /// @param tokens The token contract addresses
-    /// @param ticks The ticks represending the price of each token pair in the tokens array
+    /// @param ticks The ticks, representing the price of each token pair in the tokens array
     /// @return syntheticTick The synthetic tick, represneting the relative price of the outermost tokens in the token array
     function getChainedPrice(address[] memory tokens, int24[] memory ticks)
         internal
@@ -174,7 +174,7 @@ library OracleLibrary {
 
         for (uint256 i = 1; i <= ticks.length; i++) {
             // check the tokens for address sort order, then accumulate the
-            // ticks into the running synthetic ticks, ensuring that intermediate tokens "cancel out"
+            // ticks into the running synthetic tick, ensuring that intermediate tokens "cancel out"
             tokens[i - 1] > tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];
 
             if (i == ticks.length) {

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -159,12 +159,12 @@ library OracleLibrary {
         if (numerator < 0 && (numerator % int256(denominator) != 0)) weightedArithmeticMeanTick--;
     }
 
-    /// @notice Returns the synthetic tick of the first token in the `tokens` array in terms of the last
-    /// @dev Useful for relative pricing needs when a `path` does not exist, or when ticks must be returned in a customized way.
-    /// fails with "descrepant length" if the number of ticks does not match the number of token pairs
+    /// @notice Returns the "synthetic" tick which represents the price of the first entry in `tokens` in terms of the last
+    /// @dev Useful for calculating relative prices along routes.
+    /// @dev There should be one tick for each pairwise set of tokens.
     /// @param tokens The token contract addresses
-    /// @param ticks The ticks, representing the price of each token pair in the tokens array
-    /// @return syntheticTick The synthetic tick, represneting the relative price of the outermost tokens in the token array
+    /// @param ticks The ticks, representing the price of each token pair in `tokens`
+    /// @return syntheticTick The synthetic tick, representing the relative price of the outermost tokens in `tokens`
     function getChainedPrice(address[] memory tokens, int24[] memory ticks)
         internal
         pure

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -159,15 +159,32 @@ library OracleLibrary {
         if (numerator < 0 && (numerator % int256(denominator) != 0)) weightedArithmeticMeanTick--;
     }
 
-    // @notice returns the price 
-    function getChainedPrice(address[] memory tokens)
-        internal 
-        view
-        returns (int256 syntheticTick) 
+    /// @notice Returns the synthetic tick of the first token in the `tokens` array in terms of the last
+    /// @dev Useful for relative pricing needs when a `path` does not exist, or when ticks must be returned in a customized way.
+    /// fails with "descrepant length" if number of ticks do not match the number of token pairs
+    /// @param tokens The token contract addresses
+    /// @param ticks The ticks represending the price of each token pair in the tokens array
+    /// @return syntheticTick The synthetic tick, represneting the relative price of the outermost tokens in the token array
+    function getChainedPrice(address[] memory tokens, int24[] memory ticks)
+        internal
+        pure
+        returns (int256 syntheticTick)
     {
-        bool lowerTicksAreWorse;
-        uint256 numTicks = path.length;
+        require(tokens.length - 1 == ticks.length, 'DL');
 
-        
+        for (uint256 i = 1; i <= ticks.length; i++) {
+            // check the tokens for address sort order, then accumulate the 
+            // ticks into the running synthetic ticks, ensuring that intermediate tokens "cancel out"
+            tokens[i - 1] > tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];
+
+            if (i == ticks.length) {
+                // check the token sort order of the final pair, ensuring that lower ticks represent a worse price
+                if (tokens[i - 1] > tokens[i]) {
+                    return syntheticTick;
+                } else {
+                    syntheticTick *= -1;
+                }
+            }
+        }
     }
 }

--- a/contracts/test/OracleTest.sol
+++ b/contracts/test/OracleTest.sol
@@ -61,11 +61,7 @@ contract OracleTest {
         return OracleLibrary.getWeightedArithmeticMeanTick(observations);
     }
 
-    function getChainedPrice(address[] memory tokens, int24[] memory ticks) 
-        public 
-        view 
-        returns (int256 syntheticTick) 
-    {
+    function getChainedPrice(address[] memory tokens, int24[] memory ticks) public view returns (int256 syntheticTick) {
         return OracleLibrary.getChainedPrice(tokens, ticks);
     }
 }

--- a/contracts/test/OracleTest.sol
+++ b/contracts/test/OracleTest.sol
@@ -60,4 +60,12 @@ contract OracleTest {
     {
         return OracleLibrary.getWeightedArithmeticMeanTick(observations);
     }
+
+    function getChainedPrice(address[] memory tokens, int24[] memory ticks) 
+        public 
+        view 
+        returns (int256 syntheticTick) 
+    {
+        return OracleLibrary.getChainedPrice(tokens, ticks);
+    }
 }

--- a/test/OracleLibrary.spec.ts
+++ b/test/OracleLibrary.spec.ts
@@ -14,8 +14,9 @@ describe('OracleLibrary', () => {
 
   const oracleTestFixture = async () => {
     const tokenFactory = await ethers.getContractFactory('TestERC20')
-    const tokens: [TestERC20, TestERC20] = [
+    const tokens: [TestERC20, TestERC20, TestERC20] = [
       (await tokenFactory.deploy(constants.MaxUint256.div(2))) as TestERC20, // do not use maxu256 to avoid overflowing
+      (await tokenFactory.deploy(constants.MaxUint256.div(2))) as TestERC20,
       (await tokenFactory.deploy(constants.MaxUint256.div(2))) as TestERC20,
     ]
 
@@ -486,6 +487,46 @@ describe('OracleLibrary', () => {
       const oracleTick = await oracle.getWeightedArithmeticMeanTick([observation1, observation2])
 
       expect(oracleTick).to.equal(-11)
+    })
+  })
+  describe('#getChainedPrice', () => {
+    let ticks: number[]
+
+    it('add two positive ticks', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(10)
+    })
+    it('add positive ticks, alt token order 1', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+      ticks = [5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(10)
+    })
+    it('add positive ticks, alt token order 2', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[2].address, tokens[0].address]
+      ticks = [5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add one positive and one negative tick', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [5, -5]
+
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add two negative ticks', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(-10)
     })
   })
 })

--- a/test/OracleLibrary.spec.ts
+++ b/test/OracleLibrary.spec.ts
@@ -489,7 +489,7 @@ describe('OracleLibrary', () => {
       expect(oracleTick).to.equal(-11)
     })
   })
-  describe.only('#getChainedPrice', () => {
+  describe('#getChainedPrice', () => {
     let ticks: number[]
 
     it('fails with discrepant length', async () => {

--- a/test/OracleLibrary.spec.ts
+++ b/test/OracleLibrary.spec.ts
@@ -489,44 +489,58 @@ describe('OracleLibrary', () => {
       expect(oracleTick).to.equal(-11)
     })
   })
-  describe('#getChainedPrice', () => {
+  describe.only('#getChainedPrice', () => {
     let ticks: number[]
 
-    it('add two positive ticks', async () => {
+    it('add two positive ticks, sorted order', async () => {
       const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
       ticks = [5, 5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(10)
     })
-    it('add positive ticks, alt token order 1', async () => {
+    it('add two negative ticks, sorted order', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add positive ticks, token1/token0 + token1/token0', async () => {
       const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
       ticks = [5, 5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add negative ticks, token1/token0 + token1/token0', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
       expect(oracleTick).to.equal(10)
     })
-    it('add positive ticks, alt token order 2', async () => {
+    it('add positive ticks, token0/token1 + token1/token0', async () => {
       const tokenAddresses = [tokens[1].address, tokens[2].address, tokens[0].address]
       ticks = [5, 5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(0)
     })
-    it('add one positive and one negative tick', async () => {
+    it('add positive ticks, token0/token1 + token0/token1', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add one positive and one negative tick, sorted order', async () => {
       const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
       ticks = [5, -5]
 
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(0)
-    })
-    it('add two negative ticks', async () => {
-      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
-      ticks = [-5, -5]
-      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
-
-      expect(oracleTick).to.equal(-10)
     })
   })
 })

--- a/test/OracleLibrary.spec.ts
+++ b/test/OracleLibrary.spec.ts
@@ -499,6 +499,20 @@ describe('OracleLibrary', () => {
 
       expect(oracleTick).to.equal(10)
     })
+    it('add one positive and one negative tick, sorted order', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add one negative and one positive tick, sorted order', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+      ticks = [-5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
     it('add two negative ticks, sorted order', async () => {
       const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
       ticks = [-5, -5]
@@ -506,41 +520,150 @@ describe('OracleLibrary', () => {
 
       expect(oracleTick).to.equal(-10)
     })
-    it('add positive ticks, token1/token0 + token1/token0', async () => {
-      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+
+    it('add two positive ticks, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[2].address, tokens[1].address]
       ticks = [5, 5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
-      expect(oracleTick).to.equal(-10)
+      expect(oracleTick).to.equal(0)
     })
-    it('add negative ticks, token1/token0 + token1/token0', async () => {
-      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
-      ticks = [-5, -5]
+    it('add one positive tick and one negative tick, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[2].address, tokens[1].address]
+      ticks = [5, -5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(10)
     })
-    it('add positive ticks, token0/token1 + token1/token0', async () => {
+    it('add one negative tick and one positive tick, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[2].address, tokens[1].address]
+      ticks = [-5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add two negative ticks, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[2].address, tokens[1].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+
+    it('add two positive ticks, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[0].address, tokens[2].address]
+      ticks = [5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add one positive tick and one negative tick, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[0].address, tokens[2].address]
+      ticks = [5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add one negative tick and one positive tick, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[0].address, tokens[2].address]
+      ticks = [-5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(10)
+    })
+    it('add two negative ticks, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[0].address, tokens[2].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+
+    it('add two positive ticks, token0/token1 + token1/token0', async () => {
       const tokenAddresses = [tokens[1].address, tokens[2].address, tokens[0].address]
       ticks = [5, 5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(0)
     })
-    it('add positive ticks, token0/token1 + token0/token1', async () => {
-      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+    it('add one positive tick and one negative tick, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[2].address, tokens[0].address]
+      ticks = [5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(10)
+    })
+    it('add one negative tick and one positive tick, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[2].address, tokens[0].address]
+      ticks = [-5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add two negative ticks, token0/token1 + token1/token0', async () => {
+      const tokenAddresses = [tokens[1].address, tokens[2].address, tokens[0].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+
+    it('add two positive ticks, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[0].address, tokens[1].address]
       ticks = [5, 5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(0)
     })
-    it('add one positive and one negative tick, sorted order', async () => {
-      const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
+    it('add one positive tick and one negative tick, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[0].address, tokens[1].address]
       ticks = [5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add one negative tick and one positive tick, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[0].address, tokens[1].address]
+      ticks = [-5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(10)
+    })
+    it('add two negative ticks, token1/token0 + token0/token1', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[0].address, tokens[1].address]
+      ticks = [-5, -5]
       const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
 
       expect(oracleTick).to.equal(0)
+    })
+
+    it('add two positive ticks, token1/token0 + token1/token0', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+      ticks = [5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(-10)
+    })
+    it('add one positive tick and one negative tick, token1/token0 + token1/token0', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+      ticks = [5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add one negative tick and one positive tick, token1/token0 + token1/token0', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+      ticks = [-5, 5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(0)
+    })
+    it('add two negative ticks, token1/token0 + token1/token0', async () => {
+      const tokenAddresses = [tokens[2].address, tokens[1].address, tokens[0].address]
+      ticks = [-5, -5]
+      const oracleTick = await oracle.getChainedPrice(tokenAddresses, ticks)
+
+      expect(oracleTick).to.equal(10)
     })
   })
 })

--- a/test/OracleLibrary.spec.ts
+++ b/test/OracleLibrary.spec.ts
@@ -492,6 +492,12 @@ describe('OracleLibrary', () => {
   describe.only('#getChainedPrice', () => {
     let ticks: number[]
 
+    it('fails with discrepant length', async () => {
+      const tokenAddresses = [tokens[0].address, tokens[2].address]
+      ticks = [5, 5]
+
+      expect(oracle.getChainedPrice(tokenAddresses, ticks)).to.be.revertedWith('DL')
+    })
     it('add two positive ticks, sorted order', async () => {
       const tokenAddresses = [tokens[0].address, tokens[1].address, tokens[2].address]
       ticks = [5, 5]

--- a/test/__snapshots__/SwapRouter.gas.spec.ts.snap
+++ b/test/__snapshots__/SwapRouter.gas.spec.ts.snap
@@ -6,32 +6,32 @@ exports[`SwapRouter gas tests #exactInput 0 -> 1 1`] = `107759`;
 
 exports[`SwapRouter gas tests #exactInput 0 -> 1 minimal 1`] = `98059`;
 
-exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127566`;
+exports[`SwapRouter gas tests #exactInput 0 -> WETH9 1`] = `127578`;
 
-exports[`SwapRouter gas tests #exactInput 2 trades (via router) 1`] = `188802`;
+exports[`SwapRouter gas tests #exactInput 2 trades (via router) 1`] = `188814`;
 
-exports[`SwapRouter gas tests #exactInput 3 trades (directly to sender) 1`] = `258589`;
+exports[`SwapRouter gas tests #exactInput 3 trades (directly to sender) 1`] = `258601`;
 
-exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `106071`;
+exports[`SwapRouter gas tests #exactInput WETH9 -> 0 1`] = `106083`;
 
 exports[`SwapRouter gas tests #exactInputSingle 0 -> 1 1`] = `107180`;
 
-exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126981`;
+exports[`SwapRouter gas tests #exactInputSingle 0 -> WETH9 1`] = `126993`;
 
-exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `105492`;
+exports[`SwapRouter gas tests #exactInputSingle WETH9 -> 0 1`] = `105504`;
 
 exports[`SwapRouter gas tests #exactOutput 0 -> 1 -> 2 1`] = `169275`;
 
 exports[`SwapRouter gas tests #exactOutput 0 -> 1 1`] = `111757`;
 
-exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128809`;
+exports[`SwapRouter gas tests #exactOutput 0 -> WETH9 1`] = `128821`;
 
-exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119679`;
+exports[`SwapRouter gas tests #exactOutput WETH9 -> 0 1`] = `119691`;
 
 exports[`SwapRouter gas tests #exactOutputSingle 0 -> 1 1`] = `111967`;
 
-exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129019`;
+exports[`SwapRouter gas tests #exactOutputSingle 0 -> WETH9 1`] = `129031`;
 
-exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `114354`;
+exports[`SwapRouter gas tests #exactOutputSingle WETH9 -> 0 1`] = `114366`;
 
-exports[`SwapRouter gas tests 3 trades (directly to sender) 1`] = `179428`;
+exports[`SwapRouter gas tests 3 trades (directly to sender) 1`] = `179440`;

--- a/test/__snapshots__/V3Migrator.spec.ts.snap
+++ b/test/__snapshots__/V3Migrator.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`V3Migrator #migrate gas 1`] = `730613`;
+exports[`V3Migrator #migrate gas 1`] = `730625`;


### PR DESCRIPTION
Creates a generalized price chaining function in the oracle library, for circumstances where a `path` does not exist, or ticks must be returned in a customized way.