### PR TITLE
Static-Callable Opinionated Oracle

### DIFF
--- a/contracts/StaticOracle.sol
+++ b/contracts/StaticOracle.sol
@@ -175,7 +175,9 @@ contract StaticOracle is IStaticOracle{
                 : OracleLibrary.getBlockStartingTickAndLiquidity(pools[i]);
         }
 
-        int24 weightedTick = OracleLibrary.getWeightedArithmeticMeanTick(tickData);
+        int24 weightedTick = tickData.length == 1
+            ? tickData[0].tick
+            : OracleLibrary.getWeightedArithmeticMeanTick(tickData);
         return OracleLibrary.getQuoteAtTick(weightedTick, baseAmount, baseToken, quoteToken);
     }    
 

--- a/contracts/StaticOracle.sol
+++ b/contracts/StaticOracle.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity =0.7.6;
+pragma abicoder v2;
+
+import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
+import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
+import './interfaces/IStaticOracle.sol';
+import './libraries/PoolAddress.sol';
+import './libraries/OracleLibrary.sol';
+
+/// @title Uniswap V3 Static Oracle
+/// @notice Oracle contract price quoting against Uniswap V3 pools
+contract StaticOracle is IStaticOracle{
+
+    /// @inheritdoc IStaticOracle
+    address public override immutable factory;
+    /// @inheritdoc IStaticOracle
+    uint8 public immutable override cardinalityPerMinute;
+    uint24[] private knownFeeTiers;
+    uint32[4] private resistancePeriods;
+
+    constructor(address _factory, uint32[4] memory _resistancePeriods, uint8 _cardinalityPerMinute) {
+        factory = _factory;
+        resistancePeriods = _resistancePeriods;
+        cardinalityPerMinute = _cardinalityPerMinute;
+
+        // Assign default fee tiers
+        knownFeeTiers.push(300);
+        knownFeeTiers.push(5000);
+        knownFeeTiers.push(10000);
+    }
+
+    /// @inheritdoc IStaticOracle
+    function periodForResistanceLevel(ManipulationResistance resistance) public override view returns (uint32) {
+        return resistancePeriods[uint256(resistance)];
+    }    
+
+    /// @inheritdoc IStaticOracle
+    function supportedFeeTiers() external override view returns (uint24[] memory) {
+        return knownFeeTiers;
+    }
+
+    /// @inheritdoc IStaticOracle
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        ManipulationResistance resistance
+    ) external override  view returns (uint256 quoteAmount) {
+        return quote(baseAmount, baseToken, quoteToken, periodForResistanceLevel(resistance));
+    }
+
+    /// @inheritdoc IStaticOracle
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        uint24[] memory feeTiers,
+        ManipulationResistance resistance
+    ) external override view returns (uint256 quoteAmount) {
+        return quote(baseAmount, baseToken, quoteToken, feeTiers, periodForResistanceLevel(resistance));
+    }
+
+    /// @inheritdoc IStaticOracle
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        address[] memory pools,
+        ManipulationResistance resistance
+    ) external override view returns (uint256 quoteAmount) {
+       return quote(baseAmount, baseToken, quoteToken, pools, periodForResistanceLevel(resistance));
+    }
+
+    /// @inheritdoc IStaticOracle
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        uint32 period
+    ) public override view returns (uint256 quoteAmount) {
+        (address[] memory queryablePools, uint definedPools) = getQueryablePoolsForTiers(baseToken, quoteToken, period);
+        return internalQuote(baseAmount, baseToken, quoteToken, queryablePools, definedPools, period);
+    }    
+
+    /// @inheritdoc IStaticOracle
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        uint24[] memory feeTiers,
+        uint32 period
+    ) public override view returns (uint256 quoteAmount) {
+        (address[] memory pools, uint definedPools) = getPoolsForTiers(baseToken, quoteToken, feeTiers);
+        require(pools.length == definedPools, 'Given tier does not have pool');
+        return quote(baseAmount, baseToken, quoteToken, pools, period);
+    }
+
+    /// @inheritdoc IStaticOracle
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        address[] memory pools,
+        uint32 period
+    ) public override view returns (uint256 quoteAmount) {
+       return internalQuote(baseAmount, baseToken, quoteToken, pools, pools.length, period);
+    }
+
+    /// @inheritdoc IStaticOracle
+    function prepare(address tokenA, address tokenB, ManipulationResistance resistance) external override {
+        prepare(tokenA, tokenB, periodForResistanceLevel(resistance));
+    }
+
+    /// @inheritdoc IStaticOracle
+    function prepare(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external override {
+        prepare(tokenA, tokenB, feeTiers, periodForResistanceLevel(resistance));
+    }
+
+    /// @inheritdoc IStaticOracle
+    function prepare(address[] calldata pools, ManipulationResistance resistance) external override {
+        prepare(pools, periodForResistanceLevel(resistance));
+    }    
+
+    /// @inheritdoc IStaticOracle
+    function prepare(address tokenA, address tokenB, uint32 period) public override {
+        (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
+        internalPrepare(pools, definedPools, period);
+    }    
+
+    /// @inheritdoc IStaticOracle
+    function prepare(address tokenA, address tokenB, uint24[] memory feeTiers, uint32 period) public override {
+        (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, feeTiers);
+        require(pools.length == definedPools, 'Given tier does not have pool');
+        prepare(pools, period);
+    }
+
+    /// @inheritdoc IStaticOracle
+    function prepare(address[] memory pools, uint32 period) public override {
+        internalPrepare(pools, pools.length, period);
+    }    
+
+    /// @inheritdoc IStaticOracle
+    function addNewFeeTeer(uint24 feeTier) external override {
+        require(IUniswapV3Factory(factory).feeAmountTickSpacing(feeTier) != 0, 'Invalid fee tier');
+        for (uint i; i < knownFeeTiers.length; i++) {
+            require(knownFeeTiers[i] != feeTier, 'Tier already supported');
+        }
+        knownFeeTiers.push(feeTier);
+    }
+
+    function internalPrepare(address[] memory pools, uint definedPools, uint32 period) private {
+        uint16 cardinality = uint16((period * cardinalityPerMinute) / 60) + 1; // We add 1 just to be on the safe side
+        for (uint i; i < definedPools; i++) {
+            IUniswapV3Pool(pools[i]).increaseObservationCardinalityNext(cardinality);
+        }
+    }
+
+    function internalQuote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        address[] memory pools,
+        uint definedPools,
+        uint32 period
+    ) public view returns (uint256 quoteAmount) {
+        require(definedPools > 0, 'No defined pools');
+
+        OracleLibrary.WeightedTickData[] memory tickData = new OracleLibrary.WeightedTickData[](definedPools);
+        for (uint256 i; i < definedPools; i++) {
+            (tickData[i].tick, tickData[i].weight) = period > 0
+                ? OracleLibrary.consult(pools[i], period)
+                : OracleLibrary.getBlockStartingTickAndLiquidity(pools[i]);
+        }
+
+        int24 weightedTick = OracleLibrary.getWeightedArithmeticMeanTick(tickData);
+        return OracleLibrary.getQuoteAtTick(weightedTick, baseAmount, baseToken, quoteToken);
+    }    
+
+    /// @notice Takes a pair and a time period, and returns all pools that could be queried for that period
+    /// @param tokenA One of the pair's tokens
+    /// @param tokenB The other of the pair's tokens
+    /// @param period The period that we want to query for
+    /// @return queryablePools All pools that can be queried
+    /// @return amount How many of the elements in `queryablePools` are actually defined
+    function getQueryablePoolsForTiers(         
+        address tokenA,
+        address tokenB,
+        uint32 period
+    ) private view returns (address[] memory queryablePools, uint amount) {        
+        (address[] memory existingPools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
+        queryablePools = new address[](definedPools);
+        for (uint i; i < definedPools; i++) {
+            if (OracleLibrary.getOldestObservationSecondsAgo(existingPools[i]) >= period) {
+                queryablePools[amount++] = existingPools[i];
+            }
+        }
+    }
+    
+    /// @notice Takes a pair and some fee tiers, and returns all pools that match those tiers
+    /// @param tokenA One of the pair's tokens
+    /// @param tokenB The other of the pair's tokens
+    /// @param feeTiers The fee tiers to consider when searching for the pair's pools
+    /// @return pools The pools for the given pair and fee tiers
+    /// @return definedPools How many of the elements in `pools` are actually defined
+    function getPoolsForTiers(address tokenA, address tokenB, uint24[] memory feeTiers) private view returns (address[] memory pools, uint definedPools) {        
+        pools = new address[](feeTiers.length);
+        for (uint i; i < feeTiers.length; i++) {
+            address pool = getPoolForTier(tokenA, tokenB, feeTiers[i]);
+            if (pool != address(0)) {
+                pools[definedPools++] = pool;
+            }
+        }
+    }    
+
+    /// @dev Returns the pool for the given token pair and fee. The pool contract may or may not exist
+    function getPoolForTier(address tokenA, address tokenB, uint24 feeTier) private view returns (address) {
+        return PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, feeTier));
+    }
+
+}

--- a/contracts/StaticOracle.sol
+++ b/contracts/StaticOracle.sol
@@ -3,25 +3,22 @@ pragma solidity =0.7.6;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
-import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import './interfaces/IStaticOracle.sol';
 import './libraries/PoolAddress.sol';
 import './libraries/OracleLibrary.sol';
 
 /// @title Uniswap V3 Static Oracle
-/// @notice Oracle contract price quoting against Uniswap V3 pools
+/// @notice Oracle contract for price quoting against Uniswap V3 pools
 contract StaticOracle is IStaticOracle{
 
     /// @inheritdoc IStaticOracle
-    address public override immutable factory;
+    IUniswapV3Factory public override immutable factory;
     /// @inheritdoc IStaticOracle
     uint8 public immutable override cardinalityPerMinute;
     uint24[] private knownFeeTiers;
-    uint32[4] private resistancePeriods;
 
-    constructor(address _factory, uint32[4] memory _resistancePeriods, uint8 _cardinalityPerMinute) {
+    constructor(IUniswapV3Factory _factory, uint8 _cardinalityPerMinute) {
         factory = _factory;
-        resistancePeriods = _resistancePeriods;
         cardinalityPerMinute = _cardinalityPerMinute;
 
         // Assign default fee tiers
@@ -31,45 +28,8 @@ contract StaticOracle is IStaticOracle{
     }
 
     /// @inheritdoc IStaticOracle
-    function periodForResistanceLevel(ManipulationResistance resistance) public override view returns (uint32) {
-        return resistancePeriods[uint256(resistance)];
-    }    
-
-    /// @inheritdoc IStaticOracle
     function supportedFeeTiers() external override view returns (uint24[] memory) {
         return knownFeeTiers;
-    }
-
-    /// @inheritdoc IStaticOracle
-    function quoteAllAvailablePoolsWithResistanceLevel(
-        uint128 baseAmount, 
-        address baseToken,
-        address quoteToken,
-        ManipulationResistance resistance
-    ) external override view returns (uint256 quoteAmount) {
-        return quoteAllAvailablePoolsWithTimePeriod(baseAmount, baseToken, quoteToken, periodForResistanceLevel(resistance));
-    }
-
-    /// @inheritdoc IStaticOracle
-    function quoteSpecificFeeTiersWithResistanceLevel(
-        uint128 baseAmount, 
-        address baseToken,
-        address quoteToken,
-        uint24[] memory feeTiers,
-        ManipulationResistance resistance
-    ) external override view returns (uint256 quoteAmount) {
-        return quoteSpecificFeeTiersWithTimePeriod(baseAmount, baseToken, quoteToken, feeTiers, periodForResistanceLevel(resistance));
-    }
-
-    /// @inheritdoc IStaticOracle
-    function quoteSpecificPoolsWithResistanceLevel(
-        uint128 baseAmount, 
-        address baseToken,
-        address quoteToken,
-        address[] memory pools,
-        ManipulationResistance resistance
-    ) external override view returns (uint256 quoteAmount) {
-       return quoteSpecificPoolsWithTimePeriod(baseAmount, baseToken, quoteToken, pools, periodForResistanceLevel(resistance));
     }
 
     /// @inheritdoc IStaticOracle
@@ -78,10 +38,9 @@ contract StaticOracle is IStaticOracle{
         address baseToken,
         address quoteToken,
         uint32 period
-    ) public override view returns (uint256 quoteAmount) {
-        (address[] memory queryablePools, uint256 definedPools) = getQueryablePoolsForTiers(baseToken, quoteToken, period);
-        require(definedPools > 0, 'No pools available');
-        return internalQuote(baseAmount, baseToken, quoteToken, queryablePools, definedPools, period);
+    ) external override view returns (uint256 quoteAmount, address[] memory queriedPools) {
+        queriedPools = getQueryablePoolsForTiers(baseToken, quoteToken, period);
+        quoteAmount = internalQuote(baseAmount, baseToken, quoteToken, queriedPools, period);
     }    
 
     /// @inheritdoc IStaticOracle
@@ -89,12 +48,12 @@ contract StaticOracle is IStaticOracle{
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
-        uint24[] memory feeTiers,
+        uint24[] calldata feeTiers,
         uint32 period
-    ) public override view returns (uint256 quoteAmount) {
-        (address[] memory pools, uint256 definedPools) = getPoolsForTiers(baseToken, quoteToken, feeTiers);
-        require(pools.length == definedPools, 'Given tier does not have pool');
-        return internalQuote(baseAmount, baseToken, quoteToken, pools, definedPools, period);
+    ) external override view returns (uint256 quoteAmount, address[] memory queriedPools) {
+        queriedPools = getPoolsForTiers(baseToken, quoteToken, feeTiers);
+        require(queriedPools.length == feeTiers.length, 'Given tier does not have pool');
+        quoteAmount = internalQuote(baseAmount, baseToken, quoteToken, queriedPools, period);
     }
 
     /// @inheritdoc IStaticOracle
@@ -102,58 +61,42 @@ contract StaticOracle is IStaticOracle{
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
-        address[] memory pools,
+        address[] calldata pools,
         uint32 period
-    ) public override view returns (uint256 quoteAmount) {
-       return internalQuote(baseAmount, baseToken, quoteToken, pools, pools.length, period);
+    ) external override view returns (uint256 quoteAmount) {
+       return internalQuote(baseAmount, baseToken, quoteToken, pools, period);
     }
 
     /// @inheritdoc IStaticOracle
-    function prepareAllAvailablePoolsWithResistanceLevel(address tokenA, address tokenB, ManipulationResistance resistance) external override {
-        prepareAllAvailablePoolsWithTimePeriod(tokenA, tokenB, periodForResistanceLevel(resistance));
-    }
-
-    /// @inheritdoc IStaticOracle
-    function prepareSpecificFeeTiersWithResistanceLevel(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external override {
-        prepareSpecificFeeTiersWithTimePeriod(tokenA, tokenB, feeTiers, periodForResistanceLevel(resistance));
-    }
-
-    /// @inheritdoc IStaticOracle
-    function prepareSpecificPoolsWithResistanceLevel(address[] calldata pools, ManipulationResistance resistance) external override {
-        prepareSpecificPoolsWithTimePeriod(pools, periodForResistanceLevel(resistance));
+    function prepareAllAvailablePoolsWithTimePeriod(address tokenA, address tokenB, uint32 period) external override returns (address[] memory preparedPools) {
+        preparedPools = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
+        internalPrepare(preparedPools, period);
     }    
 
     /// @inheritdoc IStaticOracle
-    function prepareAllAvailablePoolsWithTimePeriod(address tokenA, address tokenB, uint32 period) public override {
-        (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
-        require(definedPools > 0, 'No pools available');
-        internalPrepare(pools, definedPools, period);
-    }    
-
-    /// @inheritdoc IStaticOracle
-    function prepareSpecificFeeTiersWithTimePeriod(address tokenA, address tokenB, uint24[] memory feeTiers, uint32 period) public override {
-        (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, feeTiers);
-        require(pools.length == definedPools, 'Given tier does not have pool');
-        internalPrepare(pools, definedPools, period);
+    function prepareSpecificFeeTiersWithTimePeriod(address tokenA, address tokenB, uint24[] calldata feeTiers, uint32 period) external override returns (address[] memory preparedPools) {
+        preparedPools = getPoolsForTiers(tokenA, tokenB, feeTiers);
+        require(preparedPools.length == feeTiers.length, 'Given tier does not have pool');
+        internalPrepare(preparedPools, period);
     }
 
     /// @inheritdoc IStaticOracle
-    function prepareSpecificPoolsWithTimePeriod(address[] memory pools, uint32 period) public override {
-        internalPrepare(pools, pools.length, period);
+    function prepareSpecificPoolsWithTimePeriod(address[] calldata pools, uint32 period) external override {
+        internalPrepare(pools, period);
     }    
 
     /// @inheritdoc IStaticOracle
     function addNewFeeTeer(uint24 feeTier) external override {
-        require(IUniswapV3Factory(factory).feeAmountTickSpacing(feeTier) != 0, 'Invalid fee tier');
+        require(factory.feeAmountTickSpacing(feeTier) != 0, 'Invalid fee tier');
         for (uint i; i < knownFeeTiers.length; i++) {
             require(knownFeeTiers[i] != feeTier, 'Tier already supported');
         }
         knownFeeTiers.push(feeTier);
     }
 
-    function internalPrepare(address[] memory pools, uint definedPools, uint32 period) private {
+    function internalPrepare(address[] memory pools, uint32 period) private {
         uint16 cardinality = uint16((period * cardinalityPerMinute) / 60) + 1; // We add 1 just to be on the safe side
-        for (uint i; i < definedPools; i++) {
+        for (uint i; i < pools.length; i++) {
             IUniswapV3Pool(pools[i]).increaseObservationCardinalityNext(cardinality);
         }
     }
@@ -163,13 +106,12 @@ contract StaticOracle is IStaticOracle{
         address baseToken,
         address quoteToken,
         address[] memory pools,
-        uint definedPools,
         uint32 period
     ) private view returns (uint256 quoteAmount) {
-        require(definedPools > 0, 'No defined pools');
+        require(pools.length > 0, 'No defined pools');
 
-        OracleLibrary.WeightedTickData[] memory tickData = new OracleLibrary.WeightedTickData[](definedPools);
-        for (uint256 i; i < definedPools; i++) {
+        OracleLibrary.WeightedTickData[] memory tickData = new OracleLibrary.WeightedTickData[](pools.length);
+        for (uint256 i; i < pools.length; i++) {
             (tickData[i].tick, tickData[i].weight) = period > 0
                 ? OracleLibrary.consult(pools[i], period)
                 : OracleLibrary.getBlockStartingTickAndLiquidity(pools[i]);
@@ -186,19 +128,25 @@ contract StaticOracle is IStaticOracle{
     /// @param tokenB The other of the pair's tokens
     /// @param period The period that we want to query for
     /// @return queryablePools All pools that can be queried
-    /// @return amount How many of the elements in `queryablePools` are actually defined
-    function getQueryablePoolsForTiers(         
+    function getQueryablePoolsForTiers(
         address tokenA,
         address tokenB,
         uint32 period
-    ) private view returns (address[] memory queryablePools, uint amount) {        
-        (address[] memory existingPools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
-        queryablePools = new address[](definedPools);
-        for (uint i; i < definedPools; i++) {
+    ) private view returns (address[] memory) {
+        address[] memory existingPools = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
+        // If period is 0, then just return all existing pools
+        if (period == 0) 
+            return existingPools;
+
+        address[] memory queryablePools = new address[](existingPools.length);
+        uint256 validPools;
+        for (uint i; i < existingPools.length; i++) {
             if (OracleLibrary.getOldestObservationSecondsAgo(existingPools[i]) >= period) {
-                queryablePools[amount++] = existingPools[i];
+                queryablePools[validPools++] = existingPools[i];
             }
         }
+
+        return copyValidElementsIntoNewArray(queryablePools, validPools);
     }
     
     /// @notice Takes a pair and some fee tiers, and returns all pools that match those tiers
@@ -206,14 +154,28 @@ contract StaticOracle is IStaticOracle{
     /// @param tokenB The other of the pair's tokens
     /// @param feeTiers The fee tiers to consider when searching for the pair's pools
     /// @return pools The pools for the given pair and fee tiers
-    /// @return definedPools How many of the elements in `pools` are actually defined
-    function getPoolsForTiers(address tokenA, address tokenB, uint24[] memory feeTiers) private view returns (address[] memory pools, uint definedPools) {        
-        pools = new address[](feeTiers.length);
+    function getPoolsForTiers(address tokenA, address tokenB, uint24[] memory feeTiers) private view returns (address[] memory) {
+        address[] memory pools = new address[](feeTiers.length);
+        uint256 validPools;
         for (uint i; i < feeTiers.length; i++) {
-            address pool = PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, feeTiers[i]));
+            address pool = factory.getPool(tokenA, tokenB, feeTiers[i]);
             if (pool != address(0)) {
-                pools[definedPools++] = pool;
+                pools[validPools++] = pool;
             }
         }
-    }    
+
+        return copyValidElementsIntoNewArray(pools, validPools);
+    }
+
+    function copyValidElementsIntoNewArray(address[] memory tempArray, uint256 amountOfValidElements) private pure returns (address[] memory array) {
+        // If all elements are valid, then just return the temp array
+        if (tempArray.length == amountOfValidElements)
+            return tempArray;
+
+        // If not, then copy valid elements into new array
+        array = new address[](amountOfValidElements);
+        for (uint i; i < amountOfValidElements; i++) {
+            array[i] = tempArray[i];
+        }
+    }
 }

--- a/contracts/StaticOracle.sol
+++ b/contracts/StaticOracle.sol
@@ -80,6 +80,7 @@ contract StaticOracle is IStaticOracle{
         uint32 period
     ) public override view returns (uint256 quoteAmount) {
         (address[] memory queryablePools, uint256 definedPools) = getQueryablePoolsForTiers(baseToken, quoteToken, period);
+        require(definedPools > 0, 'No pools available');
         return internalQuote(baseAmount, baseToken, quoteToken, queryablePools, definedPools, period);
     }    
 
@@ -125,6 +126,7 @@ contract StaticOracle is IStaticOracle{
     /// @inheritdoc IStaticOracle
     function prepareAllAvailablePoolsWithTimePeriod(address tokenA, address tokenB, uint32 period) public override {
         (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
+        require(definedPools > 0, 'No pools available');
         internalPrepare(pools, definedPools, period);
     }    
 

--- a/contracts/StaticOracle.sol
+++ b/contracts/StaticOracle.sol
@@ -41,39 +41,39 @@ contract StaticOracle is IStaticOracle{
     }
 
     /// @inheritdoc IStaticOracle
-    function quote(
+    function quoteAllAvailablePoolsWithResistanceLevel(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
         ManipulationResistance resistance
-    ) external override  view returns (uint256 quoteAmount) {
-        return quote(baseAmount, baseToken, quoteToken, periodForResistanceLevel(resistance));
+    ) external override view returns (uint256 quoteAmount) {
+        return quoteAllAvailablePoolsWithTimePeriod(baseAmount, baseToken, quoteToken, periodForResistanceLevel(resistance));
     }
 
     /// @inheritdoc IStaticOracle
-    function quote(
+    function quoteSpecificFeeTiersWithResistanceLevel(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
         uint24[] memory feeTiers,
         ManipulationResistance resistance
     ) external override view returns (uint256 quoteAmount) {
-        return quote(baseAmount, baseToken, quoteToken, feeTiers, periodForResistanceLevel(resistance));
+        return quoteSpecificFeeTiersWithTimePeriod(baseAmount, baseToken, quoteToken, feeTiers, periodForResistanceLevel(resistance));
     }
 
     /// @inheritdoc IStaticOracle
-    function quote(
+    function quoteSpecificPoolsWithResistanceLevel(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
         address[] memory pools,
         ManipulationResistance resistance
     ) external override view returns (uint256 quoteAmount) {
-       return quote(baseAmount, baseToken, quoteToken, pools, periodForResistanceLevel(resistance));
+       return quoteSpecificPoolsWithTimePeriod(baseAmount, baseToken, quoteToken, pools, periodForResistanceLevel(resistance));
     }
 
     /// @inheritdoc IStaticOracle
-    function quote(
+    function quoteAllAvailablePoolsWithTimePeriod(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
@@ -84,7 +84,7 @@ contract StaticOracle is IStaticOracle{
     }    
 
     /// @inheritdoc IStaticOracle
-    function quote(
+    function quoteSpecificFeeTiersWithTimePeriod(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
@@ -97,7 +97,7 @@ contract StaticOracle is IStaticOracle{
     }
 
     /// @inheritdoc IStaticOracle
-    function quote(
+    function quoteSpecificPoolsWithTimePeriod(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
@@ -108,35 +108,35 @@ contract StaticOracle is IStaticOracle{
     }
 
     /// @inheritdoc IStaticOracle
-    function prepare(address tokenA, address tokenB, ManipulationResistance resistance) external override {
-        prepare(tokenA, tokenB, periodForResistanceLevel(resistance));
+    function prepareAllAvailablePoolsWithResistanceLevel(address tokenA, address tokenB, ManipulationResistance resistance) external override {
+        prepareAllAvailablePoolsWithTimePeriod(tokenA, tokenB, periodForResistanceLevel(resistance));
     }
 
     /// @inheritdoc IStaticOracle
-    function prepare(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external override {
-        prepare(tokenA, tokenB, feeTiers, periodForResistanceLevel(resistance));
+    function prepareSpecificFeeTiersWithResistanceLevel(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external override {
+        prepareSpecificFeeTiersWithTimePeriod(tokenA, tokenB, feeTiers, periodForResistanceLevel(resistance));
     }
 
     /// @inheritdoc IStaticOracle
-    function prepare(address[] calldata pools, ManipulationResistance resistance) external override {
-        prepare(pools, periodForResistanceLevel(resistance));
+    function prepareSpecificPoolsWithResistanceLevel(address[] calldata pools, ManipulationResistance resistance) external override {
+        prepareSpecificPoolsWithTimePeriod(pools, periodForResistanceLevel(resistance));
     }    
 
     /// @inheritdoc IStaticOracle
-    function prepare(address tokenA, address tokenB, uint32 period) public override {
+    function prepareAllAvailablePoolsWithTimePeriod(address tokenA, address tokenB, uint32 period) public override {
         (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, knownFeeTiers);
         internalPrepare(pools, definedPools, period);
     }    
 
     /// @inheritdoc IStaticOracle
-    function prepare(address tokenA, address tokenB, uint24[] memory feeTiers, uint32 period) public override {
+    function prepareSpecificFeeTiersWithTimePeriod(address tokenA, address tokenB, uint24[] memory feeTiers, uint32 period) public override {
         (address[] memory pools, uint definedPools) = getPoolsForTiers(tokenA, tokenB, feeTiers);
         require(pools.length == definedPools, 'Given tier does not have pool');
         internalPrepare(pools, definedPools, period);
     }
 
     /// @inheritdoc IStaticOracle
-    function prepare(address[] memory pools, uint32 period) public override {
+    function prepareSpecificPoolsWithTimePeriod(address[] memory pools, uint32 period) public override {
         internalPrepare(pools, pools.length, period);
     }    
 

--- a/contracts/StaticOracle.sol
+++ b/contracts/StaticOracle.sol
@@ -79,7 +79,7 @@ contract StaticOracle is IStaticOracle{
         address quoteToken,
         uint32 period
     ) public override view returns (uint256 quoteAmount) {
-        (address[] memory queryablePools, uint definedPools) = getQueryablePoolsForTiers(baseToken, quoteToken, period);
+        (address[] memory queryablePools, uint256 definedPools) = getQueryablePoolsForTiers(baseToken, quoteToken, period);
         return internalQuote(baseAmount, baseToken, quoteToken, queryablePools, definedPools, period);
     }    
 
@@ -91,7 +91,7 @@ contract StaticOracle is IStaticOracle{
         uint24[] memory feeTiers,
         uint32 period
     ) public override view returns (uint256 quoteAmount) {
-        (address[] memory pools, uint definedPools) = getPoolsForTiers(baseToken, quoteToken, feeTiers);
+        (address[] memory pools, uint256 definedPools) = getPoolsForTiers(baseToken, quoteToken, feeTiers);
         require(pools.length == definedPools, 'Given tier does not have pool');
         return quote(baseAmount, baseToken, quoteToken, pools, period);
     }
@@ -163,7 +163,7 @@ contract StaticOracle is IStaticOracle{
         address[] memory pools,
         uint definedPools,
         uint32 period
-    ) public view returns (uint256 quoteAmount) {
+    ) private view returns (uint256 quoteAmount) {
         require(definedPools > 0, 'No defined pools');
 
         OracleLibrary.WeightedTickData[] memory tickData = new OracleLibrary.WeightedTickData[](definedPools);

--- a/contracts/interfaces/IStaticOracle.sol
+++ b/contracts/interfaces/IStaticOracle.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity =0.7.6;
+
+/// @title Uniswap V3 Static Oracle
+/// @notice Oracle contract for calculating price quoting against Uniswap V3
+interface IStaticOracle {
+
+    /// @notice Levels of manipulation resistance that can be used when asking for quotes
+    enum ManipulationResistance {
+        Dangerous,
+        Weak,
+        Medium,
+        Strong
+    }
+
+    /// @notice Returns the address of the Uniswap V3 factory
+    /// @dev This value is assigned during deployment and cannot be changed
+    /// @return The address of the Uniswap V3 factory
+    function factory() external view returns (address);
+
+    /// @notice Returns how many observations can be taken per minute in Uniswap V3 oracles
+    /// @dev This value is assigned during deployment and cannot be changed
+    /// @return The cardinality per minute
+    function cardinalityPerMinute() external view returns (uint8);
+
+    /// @notice Returns, in seconds, the assigned period to the given resistance level
+    /// @dev These values are assigned during deployment and cannot be changed
+    /// @param resistance The resistance level to ask for
+    /// @return The period assigned to the given resistance level
+    function periodForResistanceLevel(ManipulationResistance resistance) external view returns (uint32);
+
+    /// @notice Returns all supported fee tiers
+    /// @return The supported fee tiers
+    function supportedFeeTiers() external view returns (uint24[] memory);
+
+    /// @notice Returns a quote, based on the given tokens and amount, by querying all of the pair's pools
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @param resistance The resistance level desired for the quote
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        ManipulationResistance resistance
+    ) external view returns (uint256 quoteAmount);
+
+    /// @notice Returns a quote, based on the given tokens and amount, by querying only the specified fee tiers
+    /// @dev Will revert if the pair does not have a pool for a given fee tier
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @param feeTiers The fee tiers to consider when calculating the quote
+    /// @param resistance The resistance level desired for the quote
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        uint24[] memory feeTiers,
+        ManipulationResistance resistance
+    ) external view returns (uint256 quoteAmount);
+
+    /// @notice Returns a quote, based on the given tokens and amount, by querying only the specified pools
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @param pools The pools to consider when calculating the quote
+    /// @param resistance The resistance level desired for the quote
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        address[] memory pools,
+        ManipulationResistance resistance
+    ) external view returns (uint256 quoteAmount);
+
+    /// @notice Returns a quote, based on the given tokens and amount, by querying all of the pair's pools
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @param period Number of seconds from which to calculate the TWAP
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        uint32 period
+    ) external view returns (uint256 quoteAmount);
+
+    /// @notice Returns a quote, based on the given tokens and amount, by querying only the specified fee tiers
+    /// @dev Will revert if the pair does not have a pool for a given fee tier
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @param feeTiers The fee tiers to consider when calculating the quote
+    /// @param period Number of seconds from which to calculate the TWAP
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        uint24[] memory feeTiers,
+        uint32 period
+    ) external view returns (uint256 quoteAmount);
+
+    /// @notice Returns a quote, based on the given tokens and amount, by querying only the specified pools
+    /// @param baseAmount Amount of token to be converted
+    /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
+    /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
+    /// @param pools The pools to consider when calculating the quote
+    /// @param period Number of seconds from which to calculate the TWAP
+    /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
+    function quote(
+        uint128 baseAmount, 
+        address baseToken,
+        address quoteToken,
+        address[] memory pools,
+        uint32 period
+    ) external view returns (uint256 quoteAmount);
+
+    /// @notice Will initialize all existing pools for the given pair, so that they can be queried with the given resistance level in the future
+    /// @param tokenA One of the pair's tokens
+    /// @param tokenB The other of the pair's tokens
+    /// @param resistance The resistance level that will be guaranteed when quoting
+    function prepare(address tokenA, address tokenB, ManipulationResistance resistance) external;
+
+    /// @notice Will initialize the pair's pools with the specified fee tiers, so that they can be queried with the given resistance level in the future
+    /// @dev Will revert if the pair does not have a pool for a given fee tier
+    /// @param tokenA One of the pair's tokens
+    /// @param tokenB The other of the pair's tokens
+    /// @param feeTiers The fee tiers to consider when searching for the pair's pools
+    /// @param resistance The resistance level that will be guaranteed when quoting
+    function prepare(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external;
+
+    /// @notice Will initialize all given pools, so that they can be queried with the given resistance level in the future
+    /// @param pools The pools to initialize
+    /// @param resistance The resistance level that will be guaranteed when quoting
+    function prepare(address[] calldata pools, ManipulationResistance resistance) external;
+    
+    /// @notice Will initialize all existing pools for the given pair, so that they can be queried with the given period in the future
+    /// @param tokenA One of the pair's tokens
+    /// @param tokenB The other of the pair's tokens
+    /// @param period The period that will be guaranteed when quoting
+    function prepare(address tokenA, address tokenB, uint32 period) external;
+    
+    /// @notice Will initialize the pair's pools with the specified fee tiers, so that they can be queried with the given period in the future
+    /// @dev Will revert if the pair does not have a pool for a given fee tier
+    /// @param tokenA One of the pair's tokens
+    /// @param tokenB The other of the pair's tokens
+    /// @param feeTiers The fee tiers to consider when searching for the pair's pools
+    /// @param period The period that will be guaranteed when quoting
+    function prepare(address tokenA, address tokenB, uint24[] memory feeTiers, uint32 period) external;
+
+    /// @notice Will initialize all given pools, so that they can be queried with the given period in the future
+    /// @param pools The pools to initialize
+    /// @param period The period that will be guaranteed when quoting
+    function prepare(address[] memory pools, uint32 period) external;    
+
+    /// @notice Adds support for a new fee tier
+    /// @dev Will revert if the given tier is invalid, or already supported
+    /// @param feeTier The new fee tier to add    
+    function addNewFeeTeer(uint24 feeTier) external;
+
+}

--- a/contracts/interfaces/IStaticOracle.sol
+++ b/contracts/interfaces/IStaticOracle.sol
@@ -39,7 +39,7 @@ interface IStaticOracle {
     /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
     /// @param resistance The resistance level desired for the quote
     /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
-    function quote(
+    function quoteAllAvailablePoolsWithResistanceLevel(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
@@ -54,11 +54,11 @@ interface IStaticOracle {
     /// @param feeTiers The fee tiers to consider when calculating the quote
     /// @param resistance The resistance level desired for the quote
     /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
-    function quote(
+    function quoteSpecificFeeTiersWithResistanceLevel(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
-        uint24[] memory feeTiers,
+        uint24[] calldata feeTiers,
         ManipulationResistance resistance
     ) external view returns (uint256 quoteAmount);
 
@@ -69,11 +69,11 @@ interface IStaticOracle {
     /// @param pools The pools to consider when calculating the quote
     /// @param resistance The resistance level desired for the quote
     /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
-    function quote(
+    function quoteSpecificPoolsWithResistanceLevel(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
-        address[] memory pools,
+        address[] calldata pools,
         ManipulationResistance resistance
     ) external view returns (uint256 quoteAmount);
 
@@ -83,7 +83,7 @@ interface IStaticOracle {
     /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
     /// @param period Number of seconds from which to calculate the TWAP
     /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
-    function quote(
+    function quoteAllAvailablePoolsWithTimePeriod(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
@@ -98,11 +98,11 @@ interface IStaticOracle {
     /// @param feeTiers The fee tiers to consider when calculating the quote
     /// @param period Number of seconds from which to calculate the TWAP
     /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
-    function quote(
+    function quoteSpecificFeeTiersWithTimePeriod(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
-        uint24[] memory feeTiers,
+        uint24[] calldata feeTiers,
         uint32 period
     ) external view returns (uint256 quoteAmount);
 
@@ -113,11 +113,11 @@ interface IStaticOracle {
     /// @param pools The pools to consider when calculating the quote
     /// @param period Number of seconds from which to calculate the TWAP
     /// @return quoteAmount Amount of quoteToken received for baseAmount of baseToken
-    function quote(
+    function quoteSpecificPoolsWithTimePeriod(
         uint128 baseAmount, 
         address baseToken,
         address quoteToken,
-        address[] memory pools,
+        address[] calldata pools,
         uint32 period
     ) external view returns (uint256 quoteAmount);
 
@@ -125,7 +125,7 @@ interface IStaticOracle {
     /// @param tokenA One of the pair's tokens
     /// @param tokenB The other of the pair's tokens
     /// @param resistance The resistance level that will be guaranteed when quoting
-    function prepare(address tokenA, address tokenB, ManipulationResistance resistance) external;
+    function prepareAllAvailablePoolsWithResistanceLevel(address tokenA, address tokenB, ManipulationResistance resistance) external;
 
     /// @notice Will initialize the pair's pools with the specified fee tiers, so that they can be queried with the given resistance level in the future
     /// @dev Will revert if the pair does not have a pool for a given fee tier
@@ -133,18 +133,18 @@ interface IStaticOracle {
     /// @param tokenB The other of the pair's tokens
     /// @param feeTiers The fee tiers to consider when searching for the pair's pools
     /// @param resistance The resistance level that will be guaranteed when quoting
-    function prepare(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external;
+    function prepareSpecificFeeTiersWithResistanceLevel(address tokenA, address tokenB, uint24[] calldata feeTiers, ManipulationResistance resistance) external;
 
     /// @notice Will initialize all given pools, so that they can be queried with the given resistance level in the future
     /// @param pools The pools to initialize
     /// @param resistance The resistance level that will be guaranteed when quoting
-    function prepare(address[] calldata pools, ManipulationResistance resistance) external;
+    function prepareSpecificPoolsWithResistanceLevel(address[] calldata pools, ManipulationResistance resistance) external;
     
     /// @notice Will initialize all existing pools for the given pair, so that they can be queried with the given period in the future
     /// @param tokenA One of the pair's tokens
     /// @param tokenB The other of the pair's tokens
     /// @param period The period that will be guaranteed when quoting
-    function prepare(address tokenA, address tokenB, uint32 period) external;
+    function prepareAllAvailablePoolsWithTimePeriod(address tokenA, address tokenB, uint32 period) external;
     
     /// @notice Will initialize the pair's pools with the specified fee tiers, so that they can be queried with the given period in the future
     /// @dev Will revert if the pair does not have a pool for a given fee tier
@@ -152,12 +152,12 @@ interface IStaticOracle {
     /// @param tokenB The other of the pair's tokens
     /// @param feeTiers The fee tiers to consider when searching for the pair's pools
     /// @param period The period that will be guaranteed when quoting
-    function prepare(address tokenA, address tokenB, uint24[] memory feeTiers, uint32 period) external;
+    function prepareSpecificFeeTiersWithTimePeriod(address tokenA, address tokenB, uint24[] calldata feeTiers, uint32 period) external;
 
     /// @notice Will initialize all given pools, so that they can be queried with the given period in the future
     /// @param pools The pools to initialize
     /// @param period The period that will be guaranteed when quoting
-    function prepare(address[] memory pools, uint32 period) external;    
+    function prepareSpecificPoolsWithTimePeriod(address[] calldata pools, uint32 period) external;    
 
     /// @notice Adds support for a new fee tier
     /// @dev Will revert if the given tier is invalid, or already supported

--- a/contracts/interfaces/IStaticOracle.sol
+++ b/contracts/interfaces/IStaticOracle.sol
@@ -18,9 +18,9 @@ interface IStaticOracle {
     /// @return The address of the Uniswap V3 factory
     function factory() external view returns (address);
 
-    /// @notice Returns how many observations can be taken per minute in Uniswap V3 oracles
+    /// @notice Returns how many observations are needed per minute in Uniswap V3 oracles, on the deployed chain
     /// @dev This value is assigned during deployment and cannot be changed
-    /// @return The cardinality per minute
+    /// @return Number of observation that are needed per minute
     function cardinalityPerMinute() external view returns (uint8);
 
     /// @notice Returns, in seconds, the assigned period to the given resistance level

--- a/contracts/interfaces/IStaticOracle.sol
+++ b/contracts/interfaces/IStaticOracle.sol
@@ -34,6 +34,7 @@ interface IStaticOracle {
     function supportedFeeTiers() external view returns (uint24[] memory);
 
     /// @notice Returns a quote, based on the given tokens and amount, by querying all of the pair's pools
+    /// @dev Will revert if there are no pools available for the pair and resistance combination
     /// @param baseAmount Amount of token to be converted
     /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
     /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
@@ -78,6 +79,7 @@ interface IStaticOracle {
     ) external view returns (uint256 quoteAmount);
 
     /// @notice Returns a quote, based on the given tokens and amount, by querying all of the pair's pools
+    /// @dev Will revert if there are no pools available for the pair and period combination
     /// @param baseAmount Amount of token to be converted
     /// @param baseToken Address of an ERC20 token contract used as the baseAmount denomination
     /// @param quoteToken Address of an ERC20 token contract used as the quoteAmount denomination
@@ -122,6 +124,7 @@ interface IStaticOracle {
     ) external view returns (uint256 quoteAmount);
 
     /// @notice Will initialize all existing pools for the given pair, so that they can be queried with the given resistance level in the future
+    /// @dev Will revert if there are no pools available for the pair and resistance combination
     /// @param tokenA One of the pair's tokens
     /// @param tokenB The other of the pair's tokens
     /// @param resistance The resistance level that will be guaranteed when quoting
@@ -141,6 +144,7 @@ interface IStaticOracle {
     function prepareSpecificPoolsWithResistanceLevel(address[] calldata pools, ManipulationResistance resistance) external;
     
     /// @notice Will initialize all existing pools for the given pair, so that they can be queried with the given period in the future
+    /// @dev Will revert if there are no pools available for the pair and period combination
     /// @param tokenA One of the pair's tokens
     /// @param tokenB The other of the pair's tokens
     /// @param period The period that will be guaranteed when quoting


### PR DESCRIPTION
TL;DR: attempt to do https://github.com/Uniswap/v3-periphery/issues/186

# Intro 
The launch of Uniswap v3 innovated in many different ways, and one of them was the addition of built-in oracles. The fact that all pools can also work as an oracle enables many different use cases. At Mean Finance, we heavily rely on these oracles to support the execution of DCA positions, so we know by experience that even though they are amazing, it's very hard to work with them. In particular, since a pair can have many different pools, it can be hard to aggregate all different prices and present them in an easy way. In the past we’ve built a library (https://github.com/Uniswap/v3-periphery/pull/146) that helps in that sense, but it still could be easier to use. That's why we believe that the development of the static-callable oracle contract that hides these difficulties is so important. 
  
We are now presenting a contract that would allow anyone to easily calculate a quote between a pair of tokens that has one or more Uniswap v3 pools. This oracle will:
 - Be completely permissionless, once deployed
 - Be configurable at deployment, so that it can work correctly in different chains
 - Calculate all quotes by weighting the different pool quotes by harmonic mean liquidity
 - Allow users to easily configure the pools so that they can be used for quoting later on

# Technical Details
The contract has two main functions: `quote` and `prepare`. The first one actually calculates a quote for a given pair, and the second one can increase the observations cardinality across the pair’s pools if needed. 
Now, when asking for a quote between two tokens, there are basically two possible different parameters than can affect said quote: 
 - The pools to use (also identifiable by their fee tiers)
 - The period to consider for the TWAP
 
Our oracle presents a public function where anyone can specify both these parameters (`pools` and `period`) and get the requested quote. But, we would also like to make things a little bit easier for everyone. So each function (`quote` and `prepare`) has 6 different versions:

1. Specifying pools and time period
2. Specifying fee tiers and time period
3. Specifying a time period, but no pools or fee tiers are specified, so that all possible tools are used
4. Same as (1), but using manipulation resistance enum
5. Same as (2), but using manipulation resistance enum
6. Same as (3), but using manipulation resistance enum

# Last Comment
There is still work to be done, such as adding the necessary tests. But we wanted to get some early feedback from you and the community first, and then we can start iterating as soon as possible :smile: