### PR TITLE
Fix decoding error in Multicall

### DIFF
--- a/contracts/base/Multicall.sol
+++ b/contracts/base/Multicall.sol
@@ -14,12 +14,12 @@ abstract contract Multicall is IMulticall {
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);
 
             if (!success) {
-                // Next 5 lines from https://ethereum.stackexchange.com/a/83577
-                if (result.length < 68) revert();
+                // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d4d8d2ed9798cc3383912a23b5e8d5cb602f7d4b/contracts/utils/Address.sol#L201
+                if (result.length == 0) revert();
                 assembly {
-                    result := add(result, 0x04)
+                    let result_size := mload(result)
+                    revert(add(0x20, result), result_size)
                 }
-                revert(abi.decode(result, (string)));
             }
 
             results[i] = result;


### PR DESCRIPTION
### Summary Of Changes

This PR aims to fix the error in decoding revert reasons that was incorrectly implemented.

### Technical Description
Early, a correct solution has been suggested [here](https://ethereum.stackexchange.com/a/110428).
But, the solution enforces it encodes the revert reason again when it finally `revert` at the end.
Rather, it doesn't need to repeat decoding and encoding.
One of the best efficient solutions might be in OpenZeppelin's [`Address.sol`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d4d8d2ed9798cc3383912a23b5e8d5cb602f7d4b/contracts/utils/Address.sol#L201)

### Deployment Notes
N/A

Closes #254 