### PR TITLE
fix compilation error with solc > 0.8, fixes #177

### DIFF
--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -33,13 +33,15 @@ library PoolAddress {
     function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
         require(key.token0 < key.token1);
         pool = address(
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        hex'ff',
-                        factory,
-                        keccak256(abi.encode(key.token0, key.token1, key.fee)),
-                        POOL_INIT_CODE_HASH
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex'ff',
+                            factory,
+                            keccak256(abi.encode(key.token0, key.token1, key.fee)),
+                            POOL_INIT_CODE_HASH
+                        )
                     )
                 )
             )


### PR DESCRIPTION
Fixes the compilation error in PoolLibrary with Solidity 0.8. Now, we first cast to uin160 before casting to address.