### PR TITLE
🐛 use solidity version range for interfaces and libraries

### DIFF
--- a/contracts/interfaces/external/IWETH9.sol
+++ b/contracts/interfaces/external/IWETH9.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity >=0.7.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/libraries/CallbackValidation.sol
+++ b/contracts/libraries/CallbackValidation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.7.6;
+pragma solidity >=0.7.0;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import './PoolAddress.sol';

--- a/contracts/libraries/HexStrings.sol
+++ b/contracts/libraries/HexStrings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.7.6;
+pragma solidity >=0.7.0;
 
 library HexStrings {
     bytes16 internal constant ALPHABET = '0123456789abcdef';

--- a/contracts/libraries/TokenRatioSortOrder.sol
+++ b/contracts/libraries/TokenRatioSortOrder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.7.6;
+pragma solidity >=0.7.0;
 
 library TokenRatioSortOrder {
     int256 constant NUMERATOR_MOST = 300;


### PR DESCRIPTION
this allows apps and integrators to use this project as a library, especially `CallbackValidation`.