### PR TITLE
Revert "bump oz versions to avoid security alerts (#261)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=10"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "3.4.2-solc-0.7",
+    "@openzeppelin/contracts": "3.4.1-solc-0.7-2",
     "@uniswap/lib": "^4.0.1-alpha",
     "@uniswap/v2-core": "1.0.1",
     "@uniswap/v3-core": "1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,10 +763,9 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@3.4.2-solc-0.7":
-  version "3.4.2-solc-0.7"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2-solc-0.7.tgz#38f4dbab672631034076ccdf2f3201fab1726635"
-  integrity sha512-W6QmqgkADuFcTLzHL8vVoNBtkwjvQRpYIAom7KiUNoLKghyx3FgH0GBjt8NRvigV1ZmMOBllvE1By1C+bi8WpA==
+"@openzeppelin/contracts@3.4.1-solc-0.7-2":
+  version "3.4.1-solc-0.7-2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
This reverts commit f98b44b85b50f0981bbc4576faab01ff35dd2a40.