### PR TITLE
Update NFTSVG.sol

### DIFF
--- a/contracts/libraries/NFTSVG.sol
+++ b/contracts/libraries/NFTSVG.sol
@@ -146,7 +146,7 @@ library NFTSVG {
                 '<linearGradient id="grad-symbol"><stop offset="0.7" stop-color="white" stop-opacity="1" /><stop offset=".95" stop-color="white" stop-opacity="0" /></linearGradient>',
                 '<mask id="fade-symbol" maskContentUnits="userSpaceOnUse"><rect width="290px" height="200px" fill="url(#grad-symbol)" /></mask></defs>',
                 '<g clip-path="url(#corners)">',
-                '<rect fill="',
+                '<rect fill="#',
                 params.color0,
                 '" x="0px" y="0px" width="290px" height="500px" />',
                 '<rect style="filter: url(#f1)" x="0px" y="0px" width="290px" height="500px" />',


### PR DESCRIPTION
Small fix on NFTSVG 

params.color0 doesn't start with "#" character 

its fixed.

<img width="786" alt="Screen Shot 2022-10-27 at 19 39 42" src="https://user-images.githubusercontent.com/10724463/198349082-d2b6b3d3-c78f-4a1f-afb8-b64dba9e55d3.png">
