### PR TITLE
Quoter contract with view methods

### DIFF
--- a/contracts/interfaces/IQuoterV3.sol
+++ b/contracts/interfaces/IQuoterV3.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+/// @title Quoter Interface
+/// @notice Supports quoting the calculated amounts from exact input or exact output swaps
+/// @dev These functions are not marked view because they rely on calling non-view functions and reverting
+/// to compute the result. They are also not gas efficient and should not be called on-chain.
+interface IQuoterV3 {
+    /// @notice Returns the amount out received for a given exact input swap without executing the swap
+    /// @param path The path of the swap, i.e. each token pair and the pool fee
+    /// @param amountIn The amount of the first token to swap
+    /// @return amountOut The amount of the last token that would be received
+    function quoteExactInput(bytes memory path, uint256 amountIn) external view returns (uint256 amountOut);
+
+    /// @notice Returns the amount out received for a given exact input but for a swap of a single pool
+    /// @param tokenIn The token being swapped in
+    /// @param tokenOut The token being swapped out
+    /// @param fee The fee of the token pool to consider for the pair
+    /// @param amountIn The desired input amount
+    /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+    /// @return amountOut The amount of `tokenOut` that would be received
+    function quoteExactInputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountIn,
+        uint160 sqrtPriceLimitX96
+    ) external view returns (uint256 amountOut);
+
+    /// @notice Returns the amount in required for a given exact output swap without executing the swap
+    /// @param path The path of the swap, i.e. each token pair and the pool fee. Path must be provided in reverse order
+    /// @param amountOut The amount of the last token to receive
+    /// @return amountIn The amount of first token required to be paid
+    function quoteExactOutput(bytes memory path, uint256 amountOut) external view returns (uint256 amountIn);
+
+    /// @notice Returns the amount in required to receive the given exact output amount but for a swap of a single pool
+    /// @param tokenIn The token being swapped in
+    /// @param tokenOut The token being swapped out
+    /// @param fee The fee of the token pool to consider for the pair
+    /// @param amountOut The desired output amount
+    /// @param sqrtPriceLimitX96 The price limit of the pool that cannot be exceeded by the swap
+    /// @return amountIn The amount required as the input for the swap in order to receive `amountOut`
+    function quoteExactOutputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountOut,
+        uint160 sqrtPriceLimitX96
+    ) external view returns (uint256 amountIn);
+}

--- a/contracts/lens/QuoterV3.sol
+++ b/contracts/lens/QuoterV3.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity =0.8.15;
+pragma abicoder v2;
+
+import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
+import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
+import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
+import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
+
+import '../interfaces/IQuoter.sol';
+import '../base/PeripheryImmutableState.sol';
+import '../libraries/Path.sol';
+import '../libraries/PoolAddress.sol';
+import '../libraries/CallbackValidation.sol';
+
+/// @title Provides quotes for swaps
+/// @notice Allows getting the expected amount out or amount in for a given swap without executing the swap
+/// @dev These functions are not gas efficient and should _not_ be called on chain. Instead, optimistically execute
+/// the swap and check the amounts in the callback.
+contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
+    using Path for bytes;
+    using SafeCast for uint256;
+
+    /// @dev Transient storage variable used to check a safety condition in exact output swaps.
+    uint256 private amountOutCached;
+
+    constructor(address _factory, address _WETH9) PeripheryImmutableState(_factory, _WETH9) {}
+
+    function getPool(
+        address tokenA,
+        address tokenB,
+        uint24 fee
+    ) private view returns (IUniswapV3Pool) {
+        return IUniswapV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee)));
+    }
+
+    /// @inheritdoc IUniswapV3SwapCallback
+    function uniswapV3SwapCallback(
+        int256 amount0Delta,
+        int256 amount1Delta,
+        bytes memory path
+    ) external view override {
+        require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
+        (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+        CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
+
+        (bool isExactInput, uint256 amountToPay, uint256 amountReceived) = amount0Delta > 0
+            ? (tokenIn < tokenOut, uint256(amount0Delta), uint256(-amount1Delta))
+            : (tokenOut < tokenIn, uint256(amount1Delta), uint256(-amount0Delta));
+        if (isExactInput) {
+            assembly {
+                let ptr := mload(0x40)
+                mstore(ptr, amountReceived)
+                revert(ptr, 32)
+            }
+        } else {
+            // if the cache has been populated, ensure that the full output amount has been received
+            if (amountOutCached != 0) require(amountReceived == amountOutCached);
+            assembly {
+                let ptr := mload(0x40)
+                mstore(ptr, amountToPay)
+                revert(ptr, 32)
+            }
+        }
+    }
+
+    /// @dev Parses a revert reason that should contain the numeric quote
+    function parseRevertReason(bytes memory reason) private pure returns (uint256) {
+        if (reason.length != 32) {
+            if (reason.length < 68) revert('Unexpected error');
+            assembly {
+                reason := add(reason, 0x04)
+            }
+            revert(abi.decode(reason, (string)));
+        }
+        return abi.decode(reason, (uint256));
+    }
+
+    /// @inheritdoc IQuoter
+    function quoteExactInputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountIn,
+        uint160 sqrtPriceLimitX96
+    ) public override returns (uint256 amountOut) {
+        bool zeroForOne = tokenIn < tokenOut;
+
+        try
+            getPool(tokenIn, tokenOut, fee).swap(
+                address(this), // address(0) might cause issues with some tokens
+                zeroForOne,
+                amountIn.toInt256(),
+                sqrtPriceLimitX96 == 0
+                    ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+                    : sqrtPriceLimitX96,
+                abi.encodePacked(tokenIn, fee, tokenOut)
+            )
+        {} catch (bytes memory reason) {
+            return parseRevertReason(reason);
+        }
+    }
+
+    /// @inheritdoc IQuoter
+    function quoteExactInput(bytes memory path, uint256 amountIn) external override returns (uint256 amountOut) {
+        while (true) {
+            bool hasMultiplePools = path.hasMultiplePools();
+
+            (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+
+            // the outputs of prior swaps become the inputs to subsequent ones
+            amountIn = quoteExactInputSingle(tokenIn, tokenOut, fee, amountIn, 0);
+
+            // decide whether to continue or terminate
+            if (hasMultiplePools) {
+                path = path.skipToken();
+            } else {
+                return amountIn;
+            }
+        }
+    }
+
+    /// @inheritdoc IQuoter
+    function quoteExactOutputSingle(
+        address tokenIn,
+        address tokenOut,
+        uint24 fee,
+        uint256 amountOut,
+        uint160 sqrtPriceLimitX96
+    ) public override returns (uint256 amountIn) {
+        bool zeroForOne = tokenIn < tokenOut;
+
+        // if no price limit has been specified, cache the output amount for comparison in the swap callback
+        if (sqrtPriceLimitX96 == 0) amountOutCached = amountOut;
+        try
+            getPool(tokenIn, tokenOut, fee).swap(
+                address(this), // address(0) might cause issues with some tokens
+                zeroForOne,
+                -amountOut.toInt256(),
+                sqrtPriceLimitX96 == 0
+                    ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+                    : sqrtPriceLimitX96,
+                abi.encodePacked(tokenOut, fee, tokenIn)
+            )
+        {} catch (bytes memory reason) {
+            if (sqrtPriceLimitX96 == 0) delete amountOutCached; // clear cache
+            return parseRevertReason(reason);
+        }
+    }
+
+    /// @inheritdoc IQuoter
+    function quoteExactOutput(bytes memory path, uint256 amountOut) external override returns (uint256 amountIn) {
+        while (true) {
+            bool hasMultiplePools = path.hasMultiplePools();
+
+            (address tokenOut, address tokenIn, uint24 fee) = path.decodeFirstPool();
+
+            // the inputs of prior swaps become the outputs of subsequent ones
+            amountOut = quoteExactOutputSingle(tokenIn, tokenOut, fee, amountOut, 0);
+
+            // decide whether to continue or terminate
+            if (hasMultiplePools) {
+                path = path.skipToken();
+            } else {
+                return amountOut;
+            }
+        }
+    }
+}

--- a/contracts/lens/QuoterV3.sol
+++ b/contracts/lens/QuoterV3.sol
@@ -3,6 +3,7 @@ pragma solidity =0.8.15;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';
+import '@uniswap/v3-core/contracts/libraries/Simulate.sol';
 import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
@@ -17,12 +18,10 @@ import '../libraries/CallbackValidation.sol';
 /// @notice Allows getting the expected amount out or amount in for a given swap without executing the swap
 /// @dev These functions are not gas efficient and should _not_ be called on chain. Instead, optimistically execute
 /// the swap and check the amounts in the callback.
-contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
+contract QuoterV3 is IQuoter, PeripheryImmutableState {
     using Path for bytes;
     using SafeCast for uint256;
-
-    /// @dev Transient storage variable used to check a safety condition in exact output swaps.
-    uint256 private amountOutCached;
+    using Simulate for IUniswapV3Pool;
 
     constructor(address _factory, address _WETH9) PeripheryImmutableState(_factory, _WETH9) {}
 
@@ -34,48 +33,6 @@ contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
         return IUniswapV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee)));
     }
 
-    /// @inheritdoc IUniswapV3SwapCallback
-    function uniswapV3SwapCallback(
-        int256 amount0Delta,
-        int256 amount1Delta,
-        bytes memory path
-    ) external view override {
-        require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
-        (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
-        CallbackValidation.verifyCallback(factory, tokenIn, tokenOut, fee);
-
-        (bool isExactInput, uint256 amountToPay, uint256 amountReceived) = amount0Delta > 0
-            ? (tokenIn < tokenOut, uint256(amount0Delta), uint256(-amount1Delta))
-            : (tokenOut < tokenIn, uint256(amount1Delta), uint256(-amount0Delta));
-        if (isExactInput) {
-            assembly {
-                let ptr := mload(0x40)
-                mstore(ptr, amountReceived)
-                revert(ptr, 32)
-            }
-        } else {
-            // if the cache has been populated, ensure that the full output amount has been received
-            if (amountOutCached != 0) require(amountReceived == amountOutCached);
-            assembly {
-                let ptr := mload(0x40)
-                mstore(ptr, amountToPay)
-                revert(ptr, 32)
-            }
-        }
-    }
-
-    /// @dev Parses a revert reason that should contain the numeric quote
-    function parseRevertReason(bytes memory reason) private pure returns (uint256) {
-        if (reason.length != 32) {
-            if (reason.length < 68) revert('Unexpected error');
-            assembly {
-                reason := add(reason, 0x04)
-            }
-            revert(abi.decode(reason, (string)));
-        }
-        return abi.decode(reason, (uint256));
-    }
-
     /// @inheritdoc IQuoter
     function quoteExactInputSingle(
         address tokenIn,
@@ -83,26 +40,21 @@ contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
         uint24 fee,
         uint256 amountIn,
         uint160 sqrtPriceLimitX96
-    ) public override returns (uint256 amountOut) {
+    ) public view override returns (uint256 amountOut) {
         bool zeroForOne = tokenIn < tokenOut;
 
-        try
-            getPool(tokenIn, tokenOut, fee).swap(
-                address(this), // address(0) might cause issues with some tokens
-                zeroForOne,
-                amountIn.toInt256(),
-                sqrtPriceLimitX96 == 0
-                    ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
-                    : sqrtPriceLimitX96,
-                abi.encodePacked(tokenIn, fee, tokenOut)
-            )
-        {} catch (bytes memory reason) {
-            return parseRevertReason(reason);
-        }
+        (int256 amount0, int256 amount1) = getPool(tokenIn, tokenOut, fee).simulateSwap(
+            zeroForOne,
+            amountIn.toInt256(),
+            sqrtPriceLimitX96 == 0
+                ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+                : sqrtPriceLimitX96
+        );
+        return zeroForOne ? uint256(-amount1) : uint256(-amount0);
     }
 
     /// @inheritdoc IQuoter
-    function quoteExactInput(bytes memory path, uint256 amountIn) external override returns (uint256 amountOut) {
+    function quoteExactInput(bytes memory path, uint256 amountIn) external view override returns (uint256 amountOut) {
         while (true) {
             bool hasMultiplePools = path.hasMultiplePools();
 
@@ -127,29 +79,21 @@ contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
         uint24 fee,
         uint256 amountOut,
         uint160 sqrtPriceLimitX96
-    ) public override returns (uint256 amountIn) {
+    ) public view override returns (uint256 amountIn) {
         bool zeroForOne = tokenIn < tokenOut;
 
-        // if no price limit has been specified, cache the output amount for comparison in the swap callback
-        if (sqrtPriceLimitX96 == 0) amountOutCached = amountOut;
-        try
-            getPool(tokenIn, tokenOut, fee).swap(
-                address(this), // address(0) might cause issues with some tokens
-                zeroForOne,
-                -amountOut.toInt256(),
-                sqrtPriceLimitX96 == 0
-                    ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
-                    : sqrtPriceLimitX96,
-                abi.encodePacked(tokenOut, fee, tokenIn)
-            )
-        {} catch (bytes memory reason) {
-            if (sqrtPriceLimitX96 == 0) delete amountOutCached; // clear cache
-            return parseRevertReason(reason);
-        }
+        (int256 amount0, int256 amount1) = getPool(tokenIn, tokenOut, fee).simulateSwap(
+            zeroForOne,
+            -amountOut.toInt256(),
+            sqrtPriceLimitX96 == 0
+                ? (zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1)
+                : sqrtPriceLimitX96
+        );
+        return zeroForOne ? uint256(amount0) : uint256(amount1);
     }
 
     /// @inheritdoc IQuoter
-    function quoteExactOutput(bytes memory path, uint256 amountOut) external override returns (uint256 amountIn) {
+    function quoteExactOutput(bytes memory path, uint256 amountOut) external view override returns (uint256 amountIn) {
         while (true) {
             bool hasMultiplePools = path.hasMultiplePools();
 

--- a/contracts/lens/QuoterV3.sol
+++ b/contracts/lens/QuoterV3.sol
@@ -8,7 +8,7 @@ import '@uniswap/v3-core/contracts/libraries/TickMath.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';
 import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
 
-import '../interfaces/IQuoter.sol';
+import '../interfaces/IQuoterV3.sol';
 import '../base/PeripheryImmutableState.sol';
 import '../libraries/Path.sol';
 import '../libraries/PoolAddress.sol';
@@ -18,7 +18,7 @@ import '../libraries/CallbackValidation.sol';
 /// @notice Allows getting the expected amount out or amount in for a given swap without executing the swap
 /// @dev These functions are not gas efficient and should _not_ be called on chain. Instead, optimistically execute
 /// the swap and check the amounts in the callback.
-contract QuoterV3 is IQuoter, PeripheryImmutableState {
+contract QuoterV3 is IQuoterV3, PeripheryImmutableState {
     using Path for bytes;
     using SafeCast for uint256;
     using Simulate for IUniswapV3Pool;
@@ -33,7 +33,7 @@ contract QuoterV3 is IQuoter, PeripheryImmutableState {
         return IUniswapV3Pool(PoolAddress.computeAddress(factory, PoolAddress.getPoolKey(tokenA, tokenB, fee)));
     }
 
-    /// @inheritdoc IQuoter
+    /// @inheritdoc IQuoterV3
     function quoteExactInputSingle(
         address tokenIn,
         address tokenOut,
@@ -53,7 +53,7 @@ contract QuoterV3 is IQuoter, PeripheryImmutableState {
         return zeroForOne ? uint256(-amount1) : uint256(-amount0);
     }
 
-    /// @inheritdoc IQuoter
+    /// @inheritdoc IQuoterV3
     function quoteExactInput(bytes memory path, uint256 amountIn) external view override returns (uint256 amountOut) {
         while (true) {
             bool hasMultiplePools = path.hasMultiplePools();
@@ -72,7 +72,7 @@ contract QuoterV3 is IQuoter, PeripheryImmutableState {
         }
     }
 
-    /// @inheritdoc IQuoter
+    /// @inheritdoc IQuoterV3
     function quoteExactOutputSingle(
         address tokenIn,
         address tokenOut,
@@ -92,7 +92,7 @@ contract QuoterV3 is IQuoter, PeripheryImmutableState {
         return zeroForOne ? uint256(amount0) : uint256(amount1);
     }
 
-    /// @inheritdoc IQuoter
+    /// @inheritdoc IQuoterV3
     function quoteExactOutput(bytes memory path, uint256 amountOut) external view override returns (uint256 amountIn) {
         while (true) {
             bool hasMultiplePools = path.hasMultiplePools();

--- a/test/QuoterV3.spec.ts
+++ b/test/QuoterV3.spec.ts
@@ -1,0 +1,201 @@
+import { Fixture } from 'ethereum-waffle'
+import { constants, Wallet } from 'ethers'
+import { ethers, waffle } from 'hardhat'
+import { MockTimeNonfungiblePositionManager, QuoterV3, TestERC20 } from '../typechain'
+import completeFixture from './shared/completeFixture'
+import { FeeAmount, MaxUint128 } from './shared/constants'
+import { encodePriceSqrt } from './shared/encodePriceSqrt'
+import { expandTo18Decimals } from './shared/expandTo18Decimals'
+import { expect } from './shared/expect'
+import { encodePath } from './shared/path'
+import { createPool } from './shared/quoter'
+
+describe('Quoter', () => {
+  let wallet: Wallet
+  let trader: Wallet
+
+  const swapRouterFixture: Fixture<{
+    nft: MockTimeNonfungiblePositionManager
+    tokens: [TestERC20, TestERC20, TestERC20]
+    quoter: QuoterV3
+  }> = async (wallets, provider) => {
+    const { weth9, factory, router, tokens, nft } = await completeFixture(wallets, provider)
+
+    // approve & fund wallets
+    for (const token of tokens) {
+      await token.approve(router.address, constants.MaxUint256)
+      await token.approve(nft.address, constants.MaxUint256)
+      await token.connect(trader).approve(router.address, constants.MaxUint256)
+      await token.transfer(trader.address, expandTo18Decimals(1_000_000))
+    }
+
+    const quoterFactory = await ethers.getContractFactory('QuoterV3')
+    quoter = (await quoterFactory.deploy(factory.address, weth9.address)) as QuoterV3
+
+    return {
+      tokens,
+      nft,
+      quoter,
+    }
+  }
+
+  let nft: MockTimeNonfungiblePositionManager
+  let tokens: [TestERC20, TestERC20, TestERC20]
+  let quoter: QuoterV3
+
+  let loadFixture: ReturnType<typeof waffle.createFixtureLoader>
+
+  before('create fixture loader', async () => {
+    const wallets = await (ethers as any).getSigners()
+    ;[wallet, trader] = wallets
+    loadFixture = waffle.createFixtureLoader(wallets)
+  })
+
+  // helper for getting weth and token balances
+  beforeEach('load fixture', async () => {
+    ;({ tokens, nft, quoter } = await loadFixture(swapRouterFixture))
+  })
+
+  describe('quotes', () => {
+    beforeEach(async () => {
+      await createPool(nft, wallet, tokens[0].address, tokens[1].address)
+      await createPool(nft, wallet, tokens[1].address, tokens[2].address)
+    })
+
+    describe('#quoteExactInput', () => {
+      it('0 -> 1', async () => {
+        const quote = await quoter.callStatic.quoteExactInput(
+          encodePath([tokens[0].address, tokens[1].address], [FeeAmount.MEDIUM]),
+          3
+        )
+
+        expect(quote).to.eq(1)
+      })
+
+      it('1 -> 0', async () => {
+        const quote = await quoter.callStatic.quoteExactInput(
+          encodePath([tokens[1].address, tokens[0].address], [FeeAmount.MEDIUM]),
+          3
+        )
+
+        expect(quote).to.eq(1)
+      })
+
+      it('0 -> 1 -> 2', async () => {
+        const quote = await quoter.callStatic.quoteExactInput(
+          encodePath(
+            tokens.map((token) => token.address),
+            [FeeAmount.MEDIUM, FeeAmount.MEDIUM]
+          ),
+          5
+        )
+
+        expect(quote).to.eq(1)
+      })
+
+      it('2 -> 1 -> 0', async () => {
+        const quote = await quoter.callStatic.quoteExactInput(
+          encodePath(tokens.map((token) => token.address).reverse(), [FeeAmount.MEDIUM, FeeAmount.MEDIUM]),
+          5
+        )
+
+        expect(quote).to.eq(1)
+      })
+    })
+
+    describe('#quoteExactInputSingle', () => {
+      it('0 -> 1', async () => {
+        const quote = await quoter.callStatic.quoteExactInputSingle(
+          tokens[0].address,
+          tokens[1].address,
+          FeeAmount.MEDIUM,
+          MaxUint128,
+          // -2%
+          encodePriceSqrt(100, 102)
+        )
+
+        expect(quote).to.eq(9852)
+      })
+
+      it('1 -> 0', async () => {
+        const quote = await quoter.callStatic.quoteExactInputSingle(
+          tokens[1].address,
+          tokens[0].address,
+          FeeAmount.MEDIUM,
+          MaxUint128,
+          // +2%
+          encodePriceSqrt(102, 100)
+        )
+
+        expect(quote).to.eq(9852)
+      })
+    })
+
+    describe('#quoteExactOutput', () => {
+      it('0 -> 1', async () => {
+        const quote = await quoter.callStatic.quoteExactOutput(
+          encodePath([tokens[1].address, tokens[0].address], [FeeAmount.MEDIUM]),
+          1
+        )
+
+        expect(quote).to.eq(3)
+      })
+
+      it('1 -> 0', async () => {
+        const quote = await quoter.callStatic.quoteExactOutput(
+          encodePath([tokens[0].address, tokens[1].address], [FeeAmount.MEDIUM]),
+          1
+        )
+
+        expect(quote).to.eq(3)
+      })
+
+      it('0 -> 1 -> 2', async () => {
+        const quote = await quoter.callStatic.quoteExactOutput(
+          encodePath(tokens.map((token) => token.address).reverse(), [FeeAmount.MEDIUM, FeeAmount.MEDIUM]),
+          1
+        )
+
+        expect(quote).to.eq(5)
+      })
+
+      it('2 -> 1 -> 0', async () => {
+        const quote = await quoter.callStatic.quoteExactOutput(
+          encodePath(
+            tokens.map((token) => token.address),
+            [FeeAmount.MEDIUM, FeeAmount.MEDIUM]
+          ),
+          1
+        )
+
+        expect(quote).to.eq(5)
+      })
+    })
+
+    describe('#quoteExactOutputSingle', () => {
+      it('0 -> 1', async () => {
+        const quote = await quoter.callStatic.quoteExactOutputSingle(
+          tokens[0].address,
+          tokens[1].address,
+          FeeAmount.MEDIUM,
+          MaxUint128,
+          encodePriceSqrt(100, 102)
+        )
+
+        expect(quote).to.eq(9981)
+      })
+
+      it('1 -> 0', async () => {
+        const quote = await quoter.callStatic.quoteExactOutputSingle(
+          tokens[1].address,
+          tokens[0].address,
+          FeeAmount.MEDIUM,
+          MaxUint128,
+          encodePriceSqrt(102, 100)
+        )
+
+        expect(quote).to.eq(9981)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

This is a proposal to add a Quoter contract with interface similar to the existing Quoter contract just that the quote functions are view. 

The contract in this PR was created simply by duplicating the existing quoter contract and replacing the try catch pool.swap logic with the simulate swap. [Simulate library](https://github.com/Uniswap/v3-core/blob/simulate/contracts/libraries/Simulate.sol) in v3-core repo which makes it feasible to have quotes under a staticcall / view function. This contract is tentatively named as QuoterV3 and it passes all the tests written for Quoter contract.

## Rationale

- Quoter and QuoterV2 contracts contain non-view quote functions. They have been intended to be consumed off-chain, however for on-chain quotes, devs either have to use Simulate library from v3-core repo (which bring in sqrt price mumbo jumbo) or just use the Quoter contracts for simplicity.
- Devs implementing standards like ERC4626 which involve functions that restrict the state mutability to "view", face issues while integrating UniswapV3 if they need quotes for multi-hop swaps. Writing logic in their codebase increases lines of code and hence audit costs.
- If Uniswap team can maintain a view quoter contract, it would improve DX while integrating UniswapV3. This can be a potential public good for Uniswap community.

Please lmk if any changes are required to be done in this PR.
