### PR TITLE
change memory to calldata

### DIFF
--- a/contracts/examples/PairFlash.sol
+++ b/contracts/examples/PairFlash.sol
@@ -121,7 +121,7 @@ contract PairFlash is IUniswapV3FlashCallback, PeripheryPayments {
 
     /// @param params The parameters necessary for flash and the callback, passed in as FlashParams
     /// @notice Calls the pools flash function with data needed in `uniswapV3FlashCallback`
-    function initFlash(FlashParams memory params) external {
+    function initFlash(FlashParams calldata params) external {
         PoolAddress.PoolKey memory poolKey =
             PoolAddress.PoolKey({token0: params.token0, token1: params.token1, fee: params.fee1});
         IUniswapV3Pool pool = IUniswapV3Pool(PoolAddress.computeAddress(factory, poolKey));

--- a/contracts/lens/Quoter.sol
+++ b/contracts/lens/Quoter.sol
@@ -38,7 +38,7 @@ contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
     function uniswapV3SwapCallback(
         int256 amount0Delta,
         int256 amount1Delta,
-        bytes memory path
+        bytes calldata path
     ) external view override {
         require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
         (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();

--- a/contracts/lens/QuoterV2.sol
+++ b/contracts/lens/QuoterV2.sol
@@ -120,7 +120,7 @@ contract QuoterV2 is IQuoterV2, IUniswapV3SwapCallback, PeripheryImmutableState 
         return (amount, sqrtPriceX96After, initializedTicksCrossed, gasEstimate);
     }
 
-    function quoteExactInputSingle(QuoteExactInputSingleParams memory params)
+    function quoteExactInputSingle(QuoteExactInputSingleParams calldata params)
         public
         override
         returns (
@@ -194,7 +194,7 @@ contract QuoterV2 is IQuoterV2, IUniswapV3SwapCallback, PeripheryImmutableState 
         }
     }
 
-    function quoteExactOutputSingle(QuoteExactOutputSingleParams memory params)
+    function quoteExactOutputSingle(QuoteExactOutputSingleParams calldata params)
         public
         override
         returns (

--- a/contracts/lens/QuoterV2.sol
+++ b/contracts/lens/QuoterV2.sol
@@ -41,7 +41,7 @@ contract QuoterV2 is IQuoterV2, IUniswapV3SwapCallback, PeripheryImmutableState 
     function uniswapV3SwapCallback(
         int256 amount0Delta,
         int256 amount1Delta,
-        bytes memory path
+        bytes calldata path
     ) external view override {
         require(amount0Delta > 0 || amount1Delta > 0); // swaps entirely within 0-liquidity regions are not supported
         (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();

--- a/contracts/lens/UniswapInterfaceMulticall.sol
+++ b/contracts/lens/UniswapInterfaceMulticall.sol
@@ -24,7 +24,7 @@ contract UniswapInterfaceMulticall {
         balance = addr.balance;
     }
 
-    function multicall(Call[] memory calls) public returns (uint256 blockNumber, Result[] memory returnData) {
+    function multicall(Call[] calldata calls) public returns (uint256 blockNumber, Result[] memory returnData) {
         blockNumber = block.number;
         returnData = new Result[](calls.length);
         for (uint256 i = 0; i < calls.length; i++) {

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -41,7 +41,7 @@ library NFTDescriptor {
         address poolAddress;
     }
 
-    function constructTokenURI(ConstructTokenURIParams memory params) public pure returns (string memory) {
+    function constructTokenURI(ConstructTokenURIParams calldata params) public pure returns (string memory) {
         string memory name = generateName(params, feeToPercentString(params.fee));
         string memory descriptionPartOne =
             generateDescriptionPartOne(


### PR DESCRIPTION
Changing the data location of function parameters from memory to calldata can save much gas.
In the following example, test4 saves about 955 units of gas.

```
    function test3(uint256[] memory amounts) public {
        uint256 amount = amounts[0];
    }

    function test4(uint256[] calldata amounts) public {
        uint256 amount = amounts[0];
    }
```