### PR TITLE
move loop invariant variables out from loop to save gas

### DIFF
--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -138,8 +138,9 @@ contract SwapRouter is
     {
         address payer = msg.sender; // msg.sender pays for the first hop
 
+        bool hasMultiplePools;
         while (true) {
-            bool hasMultiplePools = params.path.hasMultiplePools();
+            hasMultiplePools = params.path.hasMultiplePools();
 
             // the outputs of prior swaps become the inputs to subsequent ones
             params.amountIn = exactInputInternal(

--- a/contracts/base/Multicall.sol
+++ b/contracts/base/Multicall.sol
@@ -9,10 +9,11 @@ import '../interfaces/IMulticall.sol';
 abstract contract Multicall is IMulticall {
     /// @inheritdoc IMulticall
     function multicall(bytes[] calldata data) public payable override returns (bytes[] memory results) {
-        uint256 len = data.length;
-        results = new bytes[](len);
-        for (uint256 i = 0; i < len; i++) {
-            (bool success, bytes memory result) = address(this).delegatecall(data[i]);
+        results = new bytes[](data.length);
+        bool success; 
+        bytes memory result;
+        for (uint256 i = 0; i < data.length; i++) {
+            (success, result) = address(this).delegatecall(data[i]);
 
             if (!success) {
                 // Next 5 lines from https://ethereum.stackexchange.com/a/83577

--- a/contracts/base/Multicall.sol
+++ b/contracts/base/Multicall.sol
@@ -9,8 +9,9 @@ import '../interfaces/IMulticall.sol';
 abstract contract Multicall is IMulticall {
     /// @inheritdoc IMulticall
     function multicall(bytes[] calldata data) public payable override returns (bytes[] memory results) {
-        results = new bytes[](data.length);
-        for (uint256 i = 0; i < data.length; i++) {
+        uint256 len = data.length;
+        results = new bytes[](len);
+        for (uint256 i = 0; i < len; i++) {
             (bool success, bytes memory result) = address(this).delegatecall(data[i]);
 
             if (!success) {

--- a/contracts/lens/Quoter.sol
+++ b/contracts/lens/Quoter.sol
@@ -104,10 +104,14 @@ contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
 
     /// @inheritdoc IQuoter
     function quoteExactInput(bytes memory path, uint256 amountIn) external override returns (uint256 amountOut) {
+        bool hasMultiplePools;
+        address tokenIn; 
+        address tokenOut; 
+        uint24 fee;
         while (true) {
-            bool hasMultiplePools = path.hasMultiplePools();
+            hasMultiplePools = path.hasMultiplePools();
 
-            (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+            (tokenIn, tokenOut, fee) = path.decodeFirstPool();
 
             // the outputs of prior swaps become the inputs to subsequent ones
             amountIn = quoteExactInputSingle(tokenIn, tokenOut, fee, amountIn, 0);
@@ -151,10 +155,14 @@ contract Quoter is IQuoter, IUniswapV3SwapCallback, PeripheryImmutableState {
 
     /// @inheritdoc IQuoter
     function quoteExactOutput(bytes memory path, uint256 amountOut) external override returns (uint256 amountIn) {
+        bool hasMultiplePools;
+        address tokenIn; 
+        address tokenOut; 
+        uint24 fee;
         while (true) {
-            bool hasMultiplePools = path.hasMultiplePools();
+            hasMultiplePools = path.hasMultiplePools();
 
-            (address tokenOut, address tokenIn, uint24 fee) = path.decodeFirstPool();
+            (tokenOut, tokenIn, fee) = path.decodeFirstPool();
 
             // the inputs of prior swaps become the outputs of subsequent ones
             amountOut = quoteExactOutputSingle(tokenIn, tokenOut, fee, amountOut, 0);

--- a/contracts/lens/QuoterV2.sol
+++ b/contracts/lens/QuoterV2.sol
@@ -164,11 +164,18 @@ contract QuoterV2 is IQuoterV2, IUniswapV3SwapCallback, PeripheryImmutableState 
         initializedTicksCrossedList = new uint32[](path.numPools());
 
         uint256 i = 0;
+        address tokenIn; 
+        address tokenOut; 
+        uint24 fee;
+        uint256 _amountOut; 
+        uint160 _sqrtPriceX96After; 
+        uint32 _initializedTicksCrossed; 
+        uint256 _gasEstimate;
         while (true) {
-            (address tokenIn, address tokenOut, uint24 fee) = path.decodeFirstPool();
+            (tokenIn, tokenOut, fee) = path.decodeFirstPool();
 
             // the outputs of prior swaps become the inputs to subsequent ones
-            (uint256 _amountOut, uint160 _sqrtPriceX96After, uint32 _initializedTicksCrossed, uint256 _gasEstimate) =
+            (_amountOut, _sqrtPriceX96After, _initializedTicksCrossed, _gasEstimate) =
                 quoteExactInputSingle(
                     QuoteExactInputSingleParams({
                         tokenIn: tokenIn,
@@ -241,11 +248,18 @@ contract QuoterV2 is IQuoterV2, IUniswapV3SwapCallback, PeripheryImmutableState 
         initializedTicksCrossedList = new uint32[](path.numPools());
 
         uint256 i = 0;
+        address tokenIn; 
+        address tokenOut; 
+        uint24 fee;
+        uint256 _amountIn; 
+        uint160 _sqrtPriceX96After; 
+        uint32 _initializedTicksCrossed; 
+        uint256 _gasEstimate;
         while (true) {
-            (address tokenOut, address tokenIn, uint24 fee) = path.decodeFirstPool();
+            (tokenOut, tokenIn, fee) = path.decodeFirstPool();
 
             // the inputs of prior swaps become the outputs of subsequent ones
-            (uint256 _amountIn, uint160 _sqrtPriceX96After, uint32 _initializedTicksCrossed, uint256 _gasEstimate) =
+            (_amountIn, _sqrtPriceX96After, _initializedTicksCrossed, _gasEstimate) =
                 quoteExactOutputSingle(
                     QuoteExactOutputSingleParams({
                         tokenIn: tokenIn,

--- a/contracts/lens/TickLens.sol
+++ b/contracts/lens/TickLens.sol
@@ -27,10 +27,13 @@ contract TickLens is ITickLens {
         // fetch populated tick data
         int24 tickSpacing = IUniswapV3Pool(pool).tickSpacing();
         populatedTicks = new PopulatedTick[](numberOfPopulatedTicks);
+        int24 populatedTick;
+        uint128 liquidityGross; 
+        int128 liquidityNet;
         for (uint256 i = 0; i < 256; i++) {
             if (bitmap & (1 << i) > 0) {
-                int24 populatedTick = ((int24(tickBitmapIndex) << 8) + int24(i)) * tickSpacing;
-                (uint128 liquidityGross, int128 liquidityNet, , , , , , ) = IUniswapV3Pool(pool).ticks(populatedTick);
+                populatedTick = ((int24(tickBitmapIndex) << 8) + int24(i)) * tickSpacing;
+                (liquidityGross, liquidityNet, , , , , , ) = IUniswapV3Pool(pool).ticks(populatedTick);
                 populatedTicks[--numberOfPopulatedTicks] = PopulatedTick({
                     tick: populatedTick,
                     liquidityNet: liquidityNet,

--- a/contracts/lens/UniswapInterfaceMulticall.sol
+++ b/contracts/lens/UniswapInterfaceMulticall.sol
@@ -28,12 +28,19 @@ contract UniswapInterfaceMulticall {
         blockNumber = block.number;
         uint256 len = calls.length;
         returnData = new Result[](len);
+        address target; 
+        uint256 gasLimit; 
+        bytes memory callData;
+        uint256 gasLeftBefore;
+        bool success;
+        bytes memory ret;
+        uint256 gasUsed;
         for (uint256 i = 0; i < len; i++) {
-            (address target, uint256 gasLimit, bytes memory callData) =
+            (target, gasLimit, callData) =
                 (calls[i].target, calls[i].gasLimit, calls[i].callData);
-            uint256 gasLeftBefore = gasleft();
-            (bool success, bytes memory ret) = target.call{gas: gasLimit}(callData);
-            uint256 gasUsed = gasLeftBefore - gasleft();
+            gasLeftBefore = gasleft();
+            (success, ret) = target.call{gas: gasLimit}(callData);
+            gasUsed = gasLeftBefore - gasleft();
             returnData[i] = Result(success, gasUsed, ret);
         }
     }

--- a/contracts/lens/UniswapInterfaceMulticall.sol
+++ b/contracts/lens/UniswapInterfaceMulticall.sol
@@ -26,8 +26,9 @@ contract UniswapInterfaceMulticall {
 
     function multicall(Call[] memory calls) public returns (uint256 blockNumber, Result[] memory returnData) {
         blockNumber = block.number;
-        returnData = new Result[](calls.length);
-        for (uint256 i = 0; i < calls.length; i++) {
+        uint256 len = calls.length;
+        returnData = new Result[](len);
+        for (uint256 i = 0; i < len; i++) {
             (address target, uint256 gasLimit, bytes memory callData) =
                 (calls[i].target, calls[i].gasLimit, calls[i].callData);
             uint256 gasLeftBefore = gasleft();

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -85,15 +85,16 @@ library NFTDescriptor {
     function escapeQuotes(string memory symbol) internal pure returns (string memory) {
         bytes memory symbolBytes = bytes(symbol);
         uint8 quotesCount = 0;
-        for (uint8 i = 0; i < symbolBytes.length; i++) {
+        uint256 len = symbolBytes.length;
+        for (uint8 i = 0; i < len; i++) {
             if (symbolBytes[i] == '"') {
                 quotesCount++;
             }
         }
         if (quotesCount > 0) {
-            bytes memory escapedBytes = new bytes(symbolBytes.length + (quotesCount));
+            bytes memory escapedBytes = new bytes(len + (quotesCount));
             uint256 index;
-            for (uint8 i = 0; i < symbolBytes.length; i++) {
+            for (uint8 i = 0; i < len; i++) {
                 if (symbolBytes[i] == '"') {
                     escapedBytes[index++] = '\\';
                 }

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -147,9 +147,10 @@ library OracleLibrary {
 
         // Accumulates the sum of the weights
         uint256 denominator;
+        uint256 len = weightedTickData.length;
 
         // Products fit in 152 bits, so it would take an array of length ~2**104 to overflow this logic
-        for (uint256 i; i < weightedTickData.length; i++) {
+        for (uint256 i; i < len; i++) {
             numerator += weightedTickData[i].tick * int256(weightedTickData[i].weight);
             denominator += weightedTickData[i].weight;
         }
@@ -170,8 +171,9 @@ library OracleLibrary {
         pure
         returns (int256 syntheticTick)
     {
-        require(tokens.length - 1 == ticks.length, 'DL');
-        for (uint256 i = 1; i <= ticks.length; i++) {
+        uint256 len = ticks.length;
+        require(tokens.length - 1 == len, 'DL');
+        for (uint256 i = 1; i <= len; i++) {
             // check the tokens for address sort order, then accumulate the
             // ticks into the running synthetic tick, ensuring that intermediate tokens "cancel out"
             tokens[i - 1] < tokens[i] ? syntheticTick += ticks[i - 1] : syntheticTick -= ticks[i - 1];

--- a/contracts/libraries/PoolTicksCounter.sol
+++ b/contracts/libraries/PoolTicksCounter.sol
@@ -60,6 +60,7 @@ library PoolTicksCounter {
         // Count the number of initialized ticks crossed by iterating through the tick bitmap.
         // Our first mask should include the lower tick and everything to its left.
         uint256 mask = type(uint256).max << bitPosLower;
+        uint256 masked;
         while (wordPosLower <= wordPosHigher) {
             // If we're on the final tick bitmap page, ensure we only count up to our
             // ending tick.
@@ -67,7 +68,7 @@ library PoolTicksCounter {
                 mask = mask & (type(uint256).max >> (255 - bitPosHigher));
             }
 
-            uint256 masked = self.tickBitmap(wordPosLower) & mask;
+            masked = self.tickBitmap(wordPosLower) & mask;
             initializedTicksCrossed += countOneBits(masked);
             wordPosLower++;
             // Reset our mask so we consider all bits on the next iteration.


### PR DESCRIPTION
Moving loop invariant codes out from loop can save gas.
In the following demo, it can save 265 units of gas when the length of ```arr``` is 100.

```
function test1(uint256[] memory arr) public {     
        for(uint256 i = 0; i < arr.length; i++) {
        }
    }

    function test2(uint256[] memory arr) public {
        uint256 len = arr.length;
        for(uint256 i = 0; i < len; i++) {
        }
    }
```