### PR TITLE
Upgrade openzeppelin version

### DIFF
--- a/contracts/base/SelfPermit.sol
+++ b/contracts/base/SelfPermit.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.5.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '@openzeppelin/contracts/drafts/IERC20Permit.sol';
+import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Permit.sol';
 
 import '../interfaces/ISelfPermit.sol';
 import '../interfaces/external/IERC20PermitAllowed.sol';

--- a/contracts/interfaces/INonfungiblePositionManager.sol
+++ b/contracts/interfaces/INonfungiblePositionManager.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-import '@openzeppelin/contracts/token/ERC721/IERC721Metadata.sol';
-import '@openzeppelin/contracts/token/ERC721/IERC721Enumerable.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol';
 
 import './IPoolInitializer.sol';
 import './IERC721Permit.sol';


### PR DESCRIPTION
These contracts used a previous version of [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/). The changes I've made here will allow users that compile these contracts themselves an improved UX by being able to clone the `Uniswap/v3-periphery` and `OpenZeppelin/openzeppelin-contracts`.

This came up for me personally in generating Rust bindings using Foundry.