### PR TITLE
remove redundant payable keyword

### DIFF
--- a/contracts/base/SelfPermit.sol
+++ b/contracts/base/SelfPermit.sol
@@ -20,7 +20,7 @@ abstract contract SelfPermit is ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public payable override {
+    ) public override {
         IERC20Permit(token).permit(msg.sender, address(this), value, deadline, v, r, s);
     }
 
@@ -32,7 +32,7 @@ abstract contract SelfPermit is ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external payable override {
+    ) external override {
         if (IERC20(token).allowance(msg.sender, address(this)) < value) selfPermit(token, value, deadline, v, r, s);
     }
 
@@ -44,7 +44,7 @@ abstract contract SelfPermit is ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public payable override {
+    ) public override {
         IERC20PermitAllowed(token).permit(msg.sender, address(this), nonce, expiry, true, v, r, s);
     }
 
@@ -56,7 +56,7 @@ abstract contract SelfPermit is ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external payable override {
+    ) external override {
         if (IERC20(token).allowance(msg.sender, address(this)) < type(uint256).max)
             selfPermitAllowed(token, nonce, expiry, v, r, s);
     }

--- a/contracts/interfaces/ISelfPermit.sol
+++ b/contracts/interfaces/ISelfPermit.sol
@@ -19,7 +19,7 @@ interface ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external payable;
+    ) external;
 
     /// @notice Permits this contract to spend a given token from `msg.sender`
     /// @dev The `owner` is always msg.sender and the `spender` is always address(this).
@@ -37,7 +37,7 @@ interface ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external payable;
+    ) external;
 
     /// @notice Permits this contract to spend the sender's tokens for permit signatures that have the `allowed` parameter
     /// @dev The `owner` is always msg.sender and the `spender` is always address(this)
@@ -54,7 +54,7 @@ interface ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external payable;
+    ) external;
 
     /// @notice Permits this contract to spend the sender's tokens for permit signatures that have the `allowed` parameter
     /// @dev The `owner` is always msg.sender and the `spender` is always address(this)
@@ -72,5 +72,5 @@ interface ISelfPermit {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external payable;
+    ) external;
 }


### PR DESCRIPTION
The `payable` keywords for functions in the `SelfPermit` contract are redundant.

Per the [specification of the EIP-2612](https://eips.ethereum.org/EIPS/eip-2612), the `permit` function does not need a `payable` keyword.
```
function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external
```

The test file for the `SelfPermit` contract does not verify the `payable` related logic, which implies the `payable` keyword is unnecessary:
```
...
  describe('#selfPermit', () => {
    const value = 456

    it('works', async () => {
      const { v, r, s } = await getPermitSignature(wallet, token, selfPermitTest.address, value)

      expect(await token.allowance(wallet.address, selfPermitTest.address)).to.be.eq(0)
      await selfPermitTest.selfPermit(token.address, value, constants.MaxUint256, v, r, s)
      expect(await token.allowance(wallet.address, selfPermitTest.address)).to.be.eq(value)
    })

    it('fails if permit is submitted externally', async () => {
      const { v, r, s } = await getPermitSignature(wallet, token, selfPermitTest.address, value)

      expect(await token.allowance(wallet.address, selfPermitTest.address)).to.be.eq(0)
      await token['permit(address,address,uint256,uint256,uint8,bytes32,bytes32)'](
        wallet.address,
        selfPermitTest.address,
        value,
        constants.MaxUint256,
        v,
        r,
        s
      )
      expect(await token.allowance(wallet.address, selfPermitTest.address)).to.be.eq(value)

      await expect(selfPermitTest.selfPermit(token.address, value, constants.MaxUint256, v, r, s)).to.be.revertedWith(
        'ERC20Permit: invalid signature'
      )
    })
  })
...
```

On the other hand, the `payable` keyword increases the risk of locking ether, due to the lack of the ether withdraw function in the `SelfPermit` contract and its derivative contracts.

Recommend removing the redundant `payable` keywords and reducing the risk of locking the ether.