### PR TITLE
declaring return variable in function's declaration to save gas

### DIFF
--- a/contracts/libraries/BytesLib.sol
+++ b/contracts/libraries/BytesLib.sol
@@ -13,12 +13,10 @@ library BytesLib {
         bytes memory _bytes,
         uint256 _start,
         uint256 _length
-    ) internal pure returns (bytes memory) {
+    ) internal pure returns (bytes memory tempBytes) {
         require(_length + 31 >= _length, 'slice_overflow');
         require(_start + _length >= _start, 'slice_overflow');
         require(_bytes.length >= _start + _length, 'slice_outOfBounds');
-
-        bytes memory tempBytes;
 
         assembly {
             switch iszero(_length)
@@ -75,10 +73,9 @@ library BytesLib {
         return tempBytes;
     }
 
-    function toAddress(bytes memory _bytes, uint256 _start) internal pure returns (address) {
+    function toAddress(bytes memory _bytes, uint256 _start) internal pure returns (address tempAddress) {
         require(_start + 20 >= _start, 'toAddress_overflow');
         require(_bytes.length >= _start + 20, 'toAddress_outOfBounds');
-        address tempAddress;
 
         assembly {
             tempAddress := div(mload(add(add(_bytes, 0x20), _start)), 0x1000000000000000000000000)
@@ -87,10 +84,9 @@ library BytesLib {
         return tempAddress;
     }
 
-    function toUint24(bytes memory _bytes, uint256 _start) internal pure returns (uint24) {
+    function toUint24(bytes memory _bytes, uint256 _start) internal pure returns (uint24 tempUint) {
         require(_start + 3 >= _start, 'toUint24_overflow');
         require(_bytes.length >= _start + 3, 'toUint24_outOfBounds');
-        uint24 tempUint;
 
         assembly {
             tempUint := mload(add(add(_bytes, 0x3), _start))

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -250,8 +250,7 @@ library NFTDescriptor {
         }
     }
 
-    function sigfigsRounded(uint256 value, uint8 digits) private pure returns (uint256, bool) {
-        bool extraDigit;
+    function sigfigsRounded(uint256 value, uint8 digits) private pure returns (uint256, bool extraDigit) {
         if (digits > 5) {
             value = value.div((10**(digits - 5)));
         }

--- a/contracts/libraries/OracleLibrary.sol
+++ b/contracts/libraries/OracleLibrary.sol
@@ -90,7 +90,7 @@ library OracleLibrary {
     /// @notice Given a pool, it returns the tick value as of the start of the current block
     /// @param pool Address of Uniswap V3 pool
     /// @return The tick that the pool was in at the start of the current block
-    function getBlockStartingTickAndLiquidity(address pool) internal view returns (int24, uint128) {
+    function getBlockStartingTickAndLiquidity(address pool) internal view returns (int24, uint128 liquidity) {
         (, int24 tick, uint16 observationIndex, uint16 observationCardinality, , , ) = IUniswapV3Pool(pool).slot0();
 
         // 2 observations are needed to reliably calculate the block starting tick
@@ -117,7 +117,7 @@ library OracleLibrary {
 
         uint32 delta = observationTimestamp - prevObservationTimestamp;
         tick = int24((tickCumulative - prevTickCumulative) / delta);
-        uint128 liquidity =
+        liquidity =
             uint128(
                 (uint192(delta) * type(uint160).max) /
                     (uint192(secondsPerLiquidityCumulativeX128 - prevSecondsPerLiquidityCumulativeX128) << 32)

--- a/contracts/libraries/PoolTicksCounter.sol
+++ b/contracts/libraries/PoolTicksCounter.sol
@@ -85,8 +85,8 @@ library PoolTicksCounter {
         return initializedTicksCrossed;
     }
 
-    function countOneBits(uint256 x) private pure returns (uint16) {
-        uint16 bits = 0;
+    function countOneBits(uint256 x) private pure returns (uint16 bits) {
+        bits = 0;
         while (x != 0) {
             bits++;
             x &= (x - 1);


### PR DESCRIPTION
If returning a local variable, solidity will create a local variable and copy its value to the stack variable that represents the return variable. This consumes more gas than declaring return variable in function's declaration.