### PR TITLE
Update INonfungiblePositionManager.sol @openzeppelin imports

### DIFF
--- a/contracts/interfaces/INonfungiblePositionManager.sol
+++ b/contracts/interfaces/INonfungiblePositionManager.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-import '@openzeppelin/contracts/token/ERC721/IERC721Metadata.sol';
-import '@openzeppelin/contracts/token/ERC721/IERC721Enumerable.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol';
 
 import './IPoolInitializer.sol';
 import './IERC721Permit.sol';


### PR DESCRIPTION
IERC721Metadata.sol and IERC721Enumerable.sol have both been moved to another endpoint.

The /extensions folder was created at @openzeppelin/contracts/token/ERC721 and the aforementioned files have been to this folder.

The @uniswap/v3-periphery library doesn't work without this change.