### PR TITLE
chore: add support version >= 0.8.15

### DIFF
--- a/contracts/NonfungiblePositionManager.sol
+++ b/contracts/NonfungiblePositionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/NonfungibleTokenPositionDescriptor.sol
+++ b/contracts/NonfungibleTokenPositionDescriptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/SwapRouter.sol
+++ b/contracts/SwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/contracts/V3Migrator.sol
+++ b/contracts/V3Migrator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';

--- a/contracts/base/BlockTimestamp.sol
+++ b/contracts/base/BlockTimestamp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 /// @title Function for getting block timestamp
 /// @dev Base contract that is overridden for tests

--- a/contracts/base/ERC721Permit.sol
+++ b/contracts/base/ERC721Permit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol';
 import '@openzeppelin/contracts/utils/Address.sol';

--- a/contracts/base/LiquidityManagement.sol
+++ b/contracts/base/LiquidityManagement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';

--- a/contracts/base/Multicall.sol
+++ b/contracts/base/Multicall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '../interfaces/IMulticall.sol';

--- a/contracts/base/PeripheryImmutableState.sol
+++ b/contracts/base/PeripheryImmutableState.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../interfaces/IPeripheryImmutableState.sol';
 

--- a/contracts/base/PeripheryValidation.sol
+++ b/contracts/base/PeripheryValidation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import './BlockTimestamp.sol';
 

--- a/contracts/base/PoolInitializer.sol
+++ b/contracts/base/PoolInitializer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Factory.sol';
 import '@uniswap/v3-core/contracts/interfaces/IUniswapV3Pool.sol';

--- a/contracts/examples/PairFlash.sol
+++ b/contracts/examples/PairFlash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3FlashCallback.sol';

--- a/contracts/interfaces/external/IWETH9.sol
+++ b/contracts/interfaces/external/IWETH9.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 

--- a/contracts/lens/Quoter.sol
+++ b/contracts/lens/Quoter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/contracts/lens/QuoterV2.sol
+++ b/contracts/lens/QuoterV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';

--- a/contracts/lens/UniswapInterfaceMulticall.sol
+++ b/contracts/lens/UniswapInterfaceMulticall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 /// @notice A fork of Multicall2 specifically tailored for the Uniswap Interface

--- a/contracts/test/Base64Test.sol
+++ b/contracts/test/Base64Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import 'base64-sol/base64.sol';
 

--- a/contracts/test/LiquidityAmountsTest.sol
+++ b/contracts/test/LiquidityAmountsTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../libraries/LiquidityAmounts.sol';
 

--- a/contracts/test/MockObservable.sol
+++ b/contracts/test/MockObservable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 contract MockObservable {
     Observation private observation0;

--- a/contracts/test/MockObservations.sol
+++ b/contracts/test/MockObservations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@uniswap/v3-core/contracts/libraries/Oracle.sol';
 

--- a/contracts/test/MockTimeNonfungiblePositionManager.sol
+++ b/contracts/test/MockTimeNonfungiblePositionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '../NonfungiblePositionManager.sol';

--- a/contracts/test/MockTimeSwapRouter.sol
+++ b/contracts/test/MockTimeSwapRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '../SwapRouter.sol';

--- a/contracts/test/NFTDescriptorTest.sol
+++ b/contracts/test/NFTDescriptorTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '../libraries/NFTDescriptor.sol';

--- a/contracts/test/NonfungiblePositionManagerPositionsGasTest.sol
+++ b/contracts/test/NonfungiblePositionManagerPositionsGasTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../interfaces/INonfungiblePositionManager.sol';
 

--- a/contracts/test/OracleTest.sol
+++ b/contracts/test/OracleTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '../libraries/OracleLibrary.sol';

--- a/contracts/test/PathTest.sol
+++ b/contracts/test/PathTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../libraries/Path.sol';
 

--- a/contracts/test/PeripheryImmutableStateTest.sol
+++ b/contracts/test/PeripheryImmutableStateTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../base/PeripheryImmutableState.sol';
 

--- a/contracts/test/PoolAddressTest.sol
+++ b/contracts/test/PoolAddressTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../libraries/PoolAddress.sol';
 

--- a/contracts/test/PositionValueTest.sol
+++ b/contracts/test/PositionValueTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../libraries/PositionValue.sol';
 import '../interfaces/INonfungiblePositionManager.sol';

--- a/contracts/test/SelfPermitTest.sol
+++ b/contracts/test/SelfPermitTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../base/SelfPermit.sol';
 

--- a/contracts/test/TestCallbackValidation.sol
+++ b/contracts/test/TestCallbackValidation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../libraries/CallbackValidation.sol';
 

--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol';
 

--- a/contracts/test/TestERC20Metadata.sol
+++ b/contracts/test/TestERC20Metadata.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol';
 

--- a/contracts/test/TestERC20PermitAllowed.sol
+++ b/contracts/test/TestERC20PermitAllowed.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import './TestERC20.sol';
 import '../interfaces/external/IERC20PermitAllowed.sol';

--- a/contracts/test/TestMulticall.sol
+++ b/contracts/test/TestMulticall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 pragma abicoder v2;
 
 import '../base/Multicall.sol';

--- a/contracts/test/TestPositionNFTOwner.sol
+++ b/contracts/test/TestPositionNFTOwner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '../interfaces/external/IERC1271.sol';
 

--- a/contracts/test/TestUniswapV3Callee.sol
+++ b/contracts/test/TestUniswapV3Callee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.15;
+pragma solidity >=0.8.15 <0.9.0;
 
 import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
 import '@uniswap/v3-core/contracts/libraries/SafeCast.sol';


### PR DESCRIPTION
sometime we need use version that latter than 0.8.15 so we have to switch solc compiler to lower version which can contains some bugs, low optimization or vulnerability. So, I think we need to support latter compiler version.