### PR TITLE
fix: add computeAddress for pools deployed with solidity 0.7.6

### DIFF
--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -49,7 +49,7 @@ library PoolAddress {
         );
     }
 
-    /// @notice Deterministically computes the pool address given the factory and PoolKey, for pools deployed with solidity 0.7.6
+    /// @notice Deterministically computes the pool address given the factory and PoolKey for pools deployed with solidity 0.7.6
     /// @param factory The Uniswap V3 factory contract address
     /// @param key The PoolKey
     /// @return pool The contract address of the V3 pool

--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.5.0;
 /// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
 library PoolAddress {
     bytes32 internal constant POOL_INIT_CODE_HASH = 0xa598dd2fba360510c5a8f02f44423a4468e902df5857dbce3ca162a43a3a31ff;
+    bytes32 internal constant POOL_INIT_CODE_HASH_0_7_6 = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
 
     /// @notice The identifying key of the pool
     struct PoolKey {
@@ -41,6 +42,28 @@ library PoolAddress {
                             factory,
                             keccak256(abi.encode(key.token0, key.token1, key.fee)),
                             POOL_INIT_CODE_HASH
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    /// @notice Deterministically computes the pool address given the factory and PoolKey, for pools deployed with solidity 0.7.6
+    /// @param factory The Uniswap V3 factory contract address
+    /// @param key The PoolKey
+    /// @return pool The contract address of the V3 pool
+    function computeAddressFor0_7_6(address factory, PoolKey memory key) internal pure returns (address pool) {
+        require(key.token0 < key.token1);
+        pool = address(
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex'ff',
+                            factory,
+                            keccak256(abi.encode(key.token0, key.token1, key.fee)),
+                            POOL_INIT_CODE_HASH_0_7_6
                         )
                     )
                 )

--- a/contracts/test/PoolAddressTest.sol
+++ b/contracts/test/PoolAddressTest.sol
@@ -8,6 +8,10 @@ contract PoolAddressTest {
         return PoolAddress.POOL_INIT_CODE_HASH;
     }
 
+    function POOL_INIT_CODE_HASH_0_7_6() external pure returns (bytes32) {
+        return PoolAddress.POOL_INIT_CODE_HASH_0_7_6;
+    }
+
     function computeAddress(
         address factory,
         address token0,
@@ -15,6 +19,15 @@ contract PoolAddressTest {
         uint24 fee
     ) external pure returns (address) {
         return PoolAddress.computeAddress(factory, PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee}));
+    }
+
+    function computeAddressFor0_7_6(
+        address factory,
+        address token0,
+        address token1,
+        uint24 fee
+    ) external pure returns (address) {
+        return PoolAddress.computeAddressFor0_7_6(factory, PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee}));
     }
 
     function getGasCostOfComputeAddress(
@@ -25,6 +38,17 @@ contract PoolAddressTest {
     ) external view returns (uint256) {
         uint256 gasBefore = gasleft();
         PoolAddress.computeAddress(factory, PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee}));
+        return gasBefore - gasleft();
+    }
+
+    function getGasCostOfComputeAddressFor0_7_6(
+        address factory,
+        address token0,
+        address token1,
+        uint24 fee
+    ) external view returns (uint256) {
+        uint256 gasBefore = gasleft();
+        PoolAddress.computeAddressFor0_7_6(factory, PoolAddress.PoolKey({token0: token0, token1: token1, fee: fee}));
         return gasBefore - gasleft();
     }
 }

--- a/test/PoolAddress.spec.ts
+++ b/test/PoolAddress.spec.ts
@@ -76,7 +76,7 @@ describe('PoolAddress', () => {
     })
   })
 
-  describe.only('#computeAddressFor0_7_6', () => {
+  describe('#computeAddressFor0_7_6', () => {
     it('all arguments equal zero', async () => {
       await expect(poolAddress.computeAddressFor0_7_6(constants.AddressZero, constants.AddressZero, constants.AddressZero, 0))
         .to.be.reverted

--- a/test/PoolAddress.spec.ts
+++ b/test/PoolAddress.spec.ts
@@ -2,7 +2,7 @@ import { constants } from 'ethers'
 import { waffle, ethers } from 'hardhat'
 
 import { PoolAddressTest } from '../typechain'
-import { POOL_BYTECODE_HASH } from './shared/computePoolAddress'
+import { POOL_BYTECODE_HASH, POOL_BYTECODE_HASH_0_7_6 } from './shared/computePoolAddress'
 import { expect } from './shared/expect'
 import snapshotGasCost from './shared/snapshotGasCost'
 
@@ -27,6 +27,12 @@ describe('PoolAddress', () => {
   describe('#POOL_INIT_CODE_HASH', () => {
     it('equals the hash of the pool bytecode', async () => {
       expect(await poolAddress.POOL_INIT_CODE_HASH()).to.eq(POOL_BYTECODE_HASH)
+    })
+  })
+
+  describe('#POOL_INIT_CODE_HASH_0_7_6', () => {
+    it('equals the hash of the pool bytecode for solidity 0.7.6', async () => {
+      expect(await poolAddress.POOL_INIT_CODE_HASH_0_7_6()).to.eq(POOL_BYTECODE_HASH_0_7_6)
     })
   })
 
@@ -61,6 +67,46 @@ describe('PoolAddress', () => {
     it('gas cost', async () => {
       await snapshotGasCost(
         poolAddress.getGasCostOfComputeAddress(
+          '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+          '0x1000000000000000000000000000000000000000',
+          '0x2000000000000000000000000000000000000000',
+          3000
+        )
+      )
+    })
+  })
+
+  describe.only('#computeAddressFor0_7_6', () => {
+    it('all arguments equal zero', async () => {
+      await expect(poolAddress.computeAddressFor0_7_6(constants.AddressZero, constants.AddressZero, constants.AddressZero, 0))
+        .to.be.reverted
+    })
+
+    it('matches example from core repo', async () => {
+      expect(
+        await poolAddress.computeAddressFor0_7_6(
+          '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+          '0x1000000000000000000000000000000000000000',
+          '0x2000000000000000000000000000000000000000',
+          250
+        )
+      ).to.matchSnapshot()
+    })
+
+    it('token argument order cannot be in reverse', async () => {
+      await expect(
+        poolAddress.computeAddressFor0_7_6(
+          '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+          '0x2000000000000000000000000000000000000000',
+          '0x1000000000000000000000000000000000000000',
+          3000
+        )
+      ).to.be.reverted
+    })
+
+    it('gas cost', async () => {
+      await snapshotGasCost(
+        poolAddress.getGasCostOfComputeAddressFor0_7_6(
           '0x5FbDB2315678afecb367f032d93F642f64180aa3',
           '0x1000000000000000000000000000000000000000',
           '0x2000000000000000000000000000000000000000',

--- a/test/__snapshots__/PoolAddress.spec.ts.snap
+++ b/test/__snapshots__/PoolAddress.spec.ts.snap
@@ -3,3 +3,7 @@
 exports[`PoolAddress #computeAddress gas cost 1`] = `643`;
 
 exports[`PoolAddress #computeAddress matches example from core repo 1`] = `"0xcf75931a4C18d87F784a91719DefFDdb74b7B0d5"`;
+
+exports[`PoolAddress #computeAddressFor0_7_6 gas cost 1`] = `644`;
+
+exports[`PoolAddress #computeAddressFor0_7_6 matches example from core repo 1`] = `"0x03D8bab195A5BC23d249693F53dfA0e358F2650D"`;

--- a/test/shared/computePoolAddress.ts
+++ b/test/shared/computePoolAddress.ts
@@ -2,6 +2,7 @@ import { bytecode } from '@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol
 import { utils } from 'ethers'
 
 export const POOL_BYTECODE_HASH = utils.keccak256(bytecode)
+export const POOL_BYTECODE_HASH_0_7_6 = '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54';
 
 export function computePoolAddress(factoryAddress: string, [tokenA, tokenB]: [string, string], fee: number): string {
   const [token0, token1] = tokenA.toLowerCase() < tokenB.toLowerCase() ? [tokenA, tokenB] : [tokenB, tokenA]


### PR DESCRIPTION
Since many users use the 0.8 branch as a library for their contracts, I added a convenient method to compute the pool addresses for most uni-v3 pools deployed with 0.7.6. A possible option is to have another `computeAddress` method that receives the `POOL_INIT_CODE_HASH` as a parameter to make it generic.
[eg. usage of PoolAddress for external contracts](https://github.com/Uniswap/v3-periphery/blob/0.8/contracts/examples/PairFlash.sol) 