### PR TITLE
Fixed issues with the interface contracts

### DIFF
--- a/contracts/interfaces/INonfungiblePositionManager.sol
+++ b/contracts/interfaces/INonfungiblePositionManager.sol
@@ -2,8 +2,10 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-import '@openzeppelin/contracts/token/ERC721/IERC721Metadata.sol';
-import '@openzeppelin/contracts/token/ERC721/IERC721Enumerable.sol';
+//Update on import statements to use the correct paths based on the latest OpenZeppelin version being used.
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol';
+import '@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol';
+
 
 import './IPoolInitializer.sol';
 import './IERC721Permit.sol';


### PR DESCRIPTION
The Solidity files in your project are using outdated import paths for OpenZeppelin libraries,Specifically in the "https://github.com/Uniswap/v3-periphery/blob/main/contracts/interfaces/INonfungiblePositionManager.sol". Specifically, the import statements reference paths that are not compatible with the latest version of OpenZeppelin. For instance, the imports:

````javascript
import '@openzeppelin/contracts/token/ERC721/IERC721Metadata.sol';
import '@openzeppelin/contracts/token/ERC721/IERC721Enumerable.sol';

````


The incorrect import paths caused the following issues:

- Compilation Errors: The contracts fail to compile, halting the development and deployment process.
- Development Delay: Additional time is required to identify and correct the import paths, leading to potential delays in project timelines.
- Integration Problems: Projects integrating with libraries or contracts expecting the correct paths will face compatibility issues.