### PR TITLE
Remove unused import

### DIFF
--- a/contracts/interfaces/INonfungiblePositionManager.sol
+++ b/contracts/interfaces/INonfungiblePositionManager.sol
@@ -9,7 +9,6 @@ import './IPoolInitializer.sol';
 import './IERC721Permit.sol';
 import './IPeripheryPayments.sol';
 import './IPeripheryImmutableState.sol';
-import '../libraries/PoolAddress.sol';
 
 /// @title Non-fungible token for positions
 /// @notice Wraps Uniswap V3 positions in a non-fungible token interface which allows for them to be transferred


### PR DESCRIPTION
The `INonfungiblePositionManager` interface imports the `PoolAddress` which is actually unused and breaks compilation with solidity 0.8.x. The removal of the import does _not_ modify the bytecode of the compiled contracts.