### PR TITLE
fix: uint256 to address explicit type conversion error

### DIFF
--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -33,13 +33,15 @@ library PoolAddress {
     function computeAddress(address factory, PoolKey memory key) internal pure returns (address pool) {
         require(key.token0 < key.token1);
         pool = address(
-            uint256(
-                keccak256(
-                    abi.encodePacked(
-                        hex'ff',
-                        factory,
-                        keccak256(abi.encode(key.token0, key.token1, key.fee)),
-                        POOL_INIT_CODE_HASH
+            uint160(
+                uint256(
+                    keccak256(
+                        abi.encodePacked(
+                            hex'ff',
+                            factory,
+                            keccak256(abi.encode(key.token0, key.token1, key.fee)),
+                            POOL_INIT_CODE_HASH
+                        )
                     )
                 )
             )


### PR DESCRIPTION
Any version of solidity greater than 0.8.0 won't allow you to convert from/to `uint256`<->`address`, so the following contracts will encounter error when compiling with newer version of solidity.
```
TypeError: Explicit type conversion not allowed from "uint256" to "address".
  --> @uniswap/v3-periphery/contracts/libraries/PoolAddress.sol:35:16:
   |
35 |         pool = address(
   |                ^ (Relevant source part starts here and spans across multiple lines).
```
So, we need to first convert `uint256` to `uint160` and then to `address`.